### PR TITLE
Add subworkflow for germline variants - GATK4 Haplotypercaller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Initial release of nf-core/autoseq, created with the [nf-core](https://nf-co.re/
 
 ### `Added`
 
+- [ #1 ](https://github.com/imsarath/nf-autoseq/pull/1) Added subworkflow for BAM QC, Reference genome configuration and nf-test integration
+- [ #3 ](https://github.com/imsarath/nf-autoseq/pull/3) Added subworkflow for somatic variant callers - GATK4 MuTect2, Hmftools - SAGE somatic
+- [ #7 ](https://github.com/imsarath/nf-autoseq/pull/7) Added subworkflow for cnv calling (Jumble) and cancer-specific information annotations.
+- [ #13 ](https://github.com/imsarath/nf-autoseq/pull/13) Added subworkflow for structural variant calling - GRIDSS
+- [ #16 ](https://github.com/imsarath/nf-autoseq/pull/16) Added subworkflow for germline variant calling - GATK4 haplotypecaller and minor bug fixes
+
 ### `Fixed`
 
 ### `Dependencies`

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -115,7 +115,7 @@ process {
     }
 
     withName: '.*:SOMATIC_SNV_CALLING:ANNOTATE_VEP' {
-        ext.args = { "--vcf --pick --filter_common --check_existing --total_length --allele_number --no_escape --no_stats --everything --offline" }
+        ext.args = { "--vcf --pick --check_existing --total_length --allele_number --no_escape --no_stats --everything --offline" }
         ext.args2 = { "-p vcf" }
         ext.prefix = { "${meta.tumor_id}_${meta.normal_id}-all.somatic.vep" }
     }
@@ -126,5 +126,20 @@ process {
 
     withName: '.*:CNV_CALLING:ANNOTATE_CNVS' {
         ext.args = { "--cancer-type ${params.cancer_type}" }
+    }
+
+    //
+    // Germline variant calling Modules
+    //
+
+    withName: '.*:GERMLINE_SNV_CALLING:GATK4_HAPLOTYPECALLER' {
+        ext.prefix = { "${meta.sample_name}_haplotypecaller" }
+    }
+
+    withName: '.*:GERMLINE_SNV_CALLING:ENSEMBLVEP_VEP' {
+        ext.args = { "--vcf --pick --filter_common --check_existing --total_length --allele_number --no_escape --no_stats --everything --offline" }
+        ext.args2 = { "-p vcf" }
+        ext.prefix = { "${meta.sample_name}-all.germline.vep" }
+
     }
 }

--- a/conf/reference_genomes.config
+++ b/conf/reference_genomes.config
@@ -7,6 +7,8 @@ params {
             fai                           = "${params.ref_genomes_base}/GRCh37/genome/human_g1k_v37_decoy.fasta.fai"
             dict                          = "${params.ref_genomes_base}/GRCh37/genome/human_g1k_v37_decoy.dict"
             bwamem2_index                 = "${params.ref_genomes_base}/GRCh37/bwamem2_index"
+            dbsnp_vcf                     = "${params.ref_genomes_base}/GRCh37/annotations/dbsnp_138.b37.vcf.gz"
+            dbsnp_vcf_tbi                 = "${params.ref_genomes_base}/GRCh37/annotations/dbsnp_138.b37.vcf.gz.tbi"
             germline_resource             = "${params.ref_genomes_base}/GRCh37/annotations/af-only-gnomad.raw.sites.vcf.gz"
             germline_resource_tbi         = "${params.ref_genomes_base}/GRCh37/annotations/af-only-gnomad.raw.sites.vcf.gz.tbi"
             clinvar_annotations           = "${params.ref_genomes_base}/GRCh37/hmfdata/clinvar.37.vcf.gz"

--- a/docs/output.md
+++ b/docs/output.md
@@ -51,6 +51,7 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
 ## Output directory structure
 
 ```
+
 results/
 ├── alignment
 ├── cnv
@@ -64,6 +65,8 @@ results/
 │   ├── germline
 │   └── somatic
 └── variants
+    └── germline
+    │   ├── haplotypecaller
     └── somatic
         ├── merged
         ├── mutect2
@@ -152,8 +155,14 @@ SAGE is a somatic SNV (Single Nucleotide Variant) caller tailored for cancer res
 
 GATK HaplotypeCaller is a robust germline variant caller that identifies SNPs and indels. It reconstructs haplotypes to ensure accurate variant calling, even in challenging genomic regions.
 
-> [NOTE]
-> Yet to be implemented
+<details markdown="1">
+<summary>Output files for GATK4 HaplotypeCaller:</summary>
+
+- `{outdir}/variants/germline/haplotypecaller`
+  - `*_haplotypecaller.vcf.gz`: germline variants in compressed vcf file format
+  - `*_haplotypecaller.vcf.tbi`: index file for germline vcf.
+
+</details>
 
 ### Structural Variant Calling
 
@@ -211,8 +220,11 @@ VEP (Variant Effect Predictor) annotates genetic variants with their predicted e
 <summary>Output files for VEP Annotation: </summary>
 
 - `{outdir}/variants/somatic/`
-  - `*.all.somatic.vep.vcf.gz`: VEP annotated variants in compressed VCF format.
-  - `*.all.somatic.vep.vcf.gz.tbi`: Index file for VEP annotated VCF.
+  - `*-all.somatic.vep.vcf.gz`: VEP annotated variants in compressed VCF format.
+  - `*-all.somatic.vep.vcf.gz.tbi`: Index file for VEP annotated VCF.
+- `{outdir}/variants/germline/`
+  - `*-all.germline.vep.vcf.gz`: VEP annotated variants in compressed VCF format.
+  - `*-all.germline.vep.vcf.gz.tbi`: Index file for VEP annotated VCF.
 
 </details>
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -34,7 +34,7 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
       - [GRIPSS](#gripss)
     - [Copy Number Variant Calling](#copy-number-variant-calling)
       - [Jumble](#jumble)
-    - [Variant Annotations](#variant-annotations)
+    - [SNVs and small InDels Annotations](#snvs-and-small-indels-annotations)
       - [VEP](#vep)
     - [Tumor Purity/Ploidy Estimation](#tumor-purityploidy-estimation)
       - [PureCN](#purecn)
@@ -210,7 +210,7 @@ Jumble is a tool for detecting copy number variants (CNVs) in sequencing data. I
 
 </details>
 
-### Variant Annotations
+### SNVs and small InDels Annotations
 
 #### VEP
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,7 +6,7 @@
 
 ## Introduction
 
-**nf-autoseq** is an automated Nextflow-based bioinformatics pipeline developed for the comprehensive analysis of cancer genomics data, specifically optimized for deep targeted sequencing and whole-exome sequencing (WES). The pipeline facilitates a reproducible, end-to-end workflow—transitioning from raw sequence reads to refined, annotated variant calls suitable for clinical and research interpretation.
+**nf-autoseq** is an automated Nextflow-based bioinformatics pipeline developed for the comprehensive analysis of cancer genomics data, specifically optimized for deep targeted sequencing and whole-exome sequencing (WES). The pipeline facilitates a reproducible, end-to-end workflow transitioning from raw sequence reads to refined, annotated variant calls suitable for clinical and research interpretation.
 
 **Note**: Currently, it is in active development and not yet ready for production use.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,7 +6,7 @@
 
 ## Introduction
 
-**nf-autoseq** is an automated Nextflow-based bioinformatics pipeline developed for the comprehensive analysis of cancer genomics data, specifically optimized for deep targeted sequencing and whole-exome sequencing (WES). The pipeline facilitates a reproducible, end-to-end workflow transitioning from raw sequence reads to refined, annotated variant calls suitable for clinical and research interpretation.
+**nf-autoseq** is an automated Nextflow-based bioinformatics pipeline developed for the comprehensive analysis of cancer genomics data, specifically optimized for deep targeted sequencing and whole-exome sequencing (WES). The pipeline facilitates a reproducible, end-to-end workflow, transitioning from raw sequence reads to refined, annotated variant calls suitable for clinical and research interpretation.
 
 **Note**: Currently, it is in active development and not yet ready for production use.
 

--- a/main.nf
+++ b/main.nf
@@ -215,7 +215,7 @@ output {
                 return 'variants/somatic/merged'
             } else if (meta.file == 'vep_vcf' || meta.file == 'vep_tbi') {
                 return 'variants/somatic'
-            } else if (meta.file == 'germline_vcf' || meta.file == 'germline_tbi' || meta.file == 'germline_hc_bam') {
+            } else if (meta.file == 'germline_vcf' || meta.file == 'germline_tbi') {
                 return 'variants/germline/haplotypecaller'
             } else if (meta.file == 'germline_vep_vcf' || meta.file == 'germline_vep_tbi') {
                 return 'variants/germline/'

--- a/main.nf
+++ b/main.nf
@@ -33,6 +33,8 @@ params.ref_genome_fasta                 = getGenomeAttribute('fasta')
 params.ref_genome_fai                   = getGenomeAttribute('fai')
 params.ref_genome_dict                  = getGenomeAttribute('dict')
 params.bwamem2_index                    = getGenomeAttribute('bwamem2_index')
+params.dbsnp_vcf                       = getGenomeAttribute('dbsnp_vcf')
+params.dbsnp_vcf_tbi                   = getGenomeAttribute('dbsnp_vcf_tbi')
 params.germline_resource                = getGenomeAttribute('germline_resource')
 params.germline_resource_tbi            = getGenomeAttribute('germline_resource_tbi')
 params.sage_known_hotspots_somatic      = getGenomeAttribute('sage_known_hotspots_somatic')
@@ -73,33 +75,35 @@ workflow NXF_AUTOSEQ {
     //
     // Initialise channels for reference genome
     //
-    ch_genome_fasta  = params.ref_genome_fasta  ? Channel.fromPath(params.ref_genome_fasta).map{ it -> [[id:'genome_fasta'], it]}.collect() : Channel.empty()
-    ch_genome_fai    = params.ref_genome_fai    ? Channel.fromPath(params.ref_genome_fai).map{ it -> [[id:'genome_fai'], it]}.collect() : Channel.empty()
-    ch_dict          = params.ref_genome_dict   ? Channel.fromPath(params.ref_genome_dict).map{ it -> [[id:'genome_dict'], it]}.collect() : Channel.empty()
-    ch_bwamem2_index = params.bwamem2_index     ? Channel.fromPath(params.bwamem2_index).map{ it -> [[id:'bwamem2_index'], it]}.collect() : Channel.empty()
+    ch_genome_fasta  = params.ref_genome_fasta  ? channel.fromPath(params.ref_genome_fasta).map{ it -> [[id:'genome_fasta'], it]}.collect() : channel.empty()
+    ch_genome_fai    = params.ref_genome_fai    ? channel.fromPath(params.ref_genome_fai).map{ it -> [[id:'genome_fai'], it]}.collect() : channel.empty()
+    ch_dict          = params.ref_genome_dict   ? channel.fromPath(params.ref_genome_dict).map{ it -> [[id:'genome_dict'], it]}.collect() : channel.empty()
+    ch_bwamem2_index = params.bwamem2_index     ? channel.fromPath(params.bwamem2_index).map{ it -> [[id:'bwamem2_index'], it]}.collect() : channel.empty()
+    ch_dbsnp_vcf      = params.dbsnp_vcf        ? channel.fromPath(params.dbsnp_vcf).map{ it -> [[id:'dbsnp_vcf'], it]}.collect() : channel.empty()
+    ch_dbsnp_vcf_tbi  = params.dbsnp_vcf_tbi  ? channel.fromPath(params.dbsnp_vcf_tbi).map{ it -> [[id:'dbsnp_vcf_tbi'], it]}.collect() : channel.empty()
 
     //
-    ch_targets_bed             = params.targets_bed ? Channel.fromPath(params.targets_bed).map{ it -> [[id:'targets_bed'], it]}.collect() : Channel.empty()
-    ch_interval_list_slopped20 = params.interval_list_slopped20 ? Channel.fromPath(params.interval_list_slopped20).map{ it -> [[id:'interval_list_slopped20'], it]}.collect() : Channel.empty()
-    ch_jumble_ref              = params.jumble_ref ? Channel.fromPath(params.jumble_ref).map{ it -> [[id:'jumble_ref'], it]}.collect() : Channel.empty()
-    ch_ensembl_vep_cache       = params.ensembl_vep_cache ? Channel.fromPath(params.ensembl_vep_cache).map{ it -> [[id:'ensembl_vep_cache'], it]}.collect() : Channel.empty()
+    ch_targets_bed             = params.targets_bed ? channel.fromPath(params.targets_bed).map{ it -> [[id:'targets_bed'], it]}.collect() : channel.empty()
+    ch_interval_list_slopped20 = params.interval_list_slopped20 ? channel.fromPath(params.interval_list_slopped20).map{ it -> [[id:'interval_list_slopped20'], it]}.collect() : channel.empty()
+    ch_jumble_ref              = params.jumble_ref ? channel.fromPath(params.jumble_ref).map{ it -> [[id:'jumble_ref'], it]}.collect() : channel.empty()
+    ch_ensembl_vep_cache       = params.ensembl_vep_cache ? channel.fromPath(params.ensembl_vep_cache).map{ it -> [[id:'ensembl_vep_cache'], it]}.collect() : channel.empty()
 
     //
-    ch_sage_known_hotspots_somatic = params.sage_known_hotspots_somatic ? Channel.fromPath(params.sage_known_hotspots_somatic).map{ it -> [[id:'sage_known_hotspots_somatic'], it]}.collect() : Channel.empty()
-    ch_sage_highconf_regions       = params.sage_highconf_regions ? Channel.fromPath(params.sage_highconf_regions).map{ it -> [[id:'sage_highconf_regions'], it]}.collect() : Channel.empty()
-    ch_sage_pon                    = params.sage_pon ? Channel.fromPath(params.sage_pon).map{ it -> [[id:'sage_pon'], it]}.collect() : Channel.empty()
-    ch_ensembl_data_resources      = params.ensembl_data_resources ? Channel.fromPath(params.ensembl_data_resources).map{ it -> [[id:'ensembl_data_resources'], it]}.collect() : Channel.empty()
-    ch_curation_ann                = params.curation_ann ? Channel.fromPath(params.curation_ann).map{ it -> [[id:'curation_ann'], it]}.collect() : Channel.empty()
-    ch_germline_resource           = params.germline_resource ? Channel.fromPath(params.germline_resource).map{ it -> [[id:'germline_resource'], it]}.collect() : Channel.empty()
-    ch_germline_resource_tbi       = params.germline_resource_tbi ? Channel.fromPath(params.germline_resource_tbi).map{ it -> [[id:'germline_resource_tbi'], it]}.collect() : Channel.empty()
+    ch_sage_known_hotspots_somatic = params.sage_known_hotspots_somatic ? channel.fromPath(params.sage_known_hotspots_somatic).map{ it -> [[id:'sage_known_hotspots_somatic'], it]}.collect() : channel.empty()
+    ch_sage_highconf_regions       = params.sage_highconf_regions ? channel.fromPath(params.sage_highconf_regions).map{ it -> [[id:'sage_highconf_regions'], it]}.collect() : channel.empty()
+    ch_sage_pon                    = params.sage_pon ? channel.fromPath(params.sage_pon).map{ it -> [[id:'sage_pon'], it]}.collect() : channel.empty()
+    ch_ensembl_data_resources      = params.ensembl_data_resources ? channel.fromPath(params.ensembl_data_resources).map{ it -> [[id:'ensembl_data_resources'], it]}.collect() : channel.empty()
+    ch_curation_ann                = params.curation_ann ? channel.fromPath(params.curation_ann).map{ it -> [[id:'curation_ann'], it]}.collect() : channel.empty()
+    ch_germline_resource           = params.germline_resource ? channel.fromPath(params.germline_resource).map{ it -> [[id:'germline_resource'], it]}.collect() : channel.empty()
+    ch_germline_resource_tbi       = params.germline_resource_tbi ? channel.fromPath(params.germline_resource_tbi).map{ it -> [[id:'germline_resource_tbi'], it]}.collect() : channel.empty()
 
     // GRIDSS-specific channels for SV calling
-    ch_genome_gridss_index = params.genome_gridss_index ? Channel.fromPath(params.genome_gridss_index).map{ it -> [[id:'genome_gridss_index'], it]}.collect() : Channel.empty()
-    ch_pon_breakends       = params.gridss_pon_breakends ? Channel.fromPath(params.gridss_pon_breakends).map{ it -> [[id:'pon_breakends'], it]}.collect() : Channel.empty()
-    ch_pon_breakpoints     = params.gridss_pon_breakpoints ? Channel.fromPath(params.gridss_pon_breakpoints).map{ it -> [[id:'pon_breakpoints'], it]}.collect() : Channel.empty()
-    ch_known_fusions       = params.gridss_known_fusions ? Channel.fromPath(params.gridss_known_fusions).map{ it -> [[id:'known_fusions'], it]}.collect() : Channel.empty()
-    ch_repeatmasker_annotations = params.gridss_repeatmasker_annotations ? Channel.fromPath(params.gridss_repeatmasker_annotations).map{ it -> [[id:'repeatmasker_annotations'], it]}.collect() : Channel.empty()
-    ch_gridss_config         = params.gridss_config ? Channel.fromPath(params.gridss_config).map{ it -> [[id: 'gridss_config'], it]}.collect() : Channel.empty()
+    ch_genome_gridss_index = params.genome_gridss_index ? channel.fromPath(params.genome_gridss_index).map{ it -> [[id:'genome_gridss_index'], it]}.collect() : channel.empty()
+    ch_pon_breakends       = params.gridss_pon_breakends ? channel.fromPath(params.gridss_pon_breakends).map{ it -> [[id:'pon_breakends'], it]}.collect() : channel.empty()
+    ch_pon_breakpoints     = params.gridss_pon_breakpoints ? channel.fromPath(params.gridss_pon_breakpoints).map{ it -> [[id:'pon_breakpoints'], it]}.collect() : channel.empty()
+    ch_known_fusions       = params.gridss_known_fusions ? channel.fromPath(params.gridss_known_fusions).map{ it -> [[id:'known_fusions'], it]}.collect() : channel.empty()
+    ch_repeatmasker_annotations = params.gridss_repeatmasker_annotations ? channel.fromPath(params.gridss_repeatmasker_annotations).map{ it -> [[id:'repeatmasker_annotations'], it]}.collect() : channel.empty()
+    ch_gridss_config         = params.gridss_config ? channel.fromPath(params.gridss_config).map{ it -> [[id: 'gridss_config'], it]}.collect() : channel.empty()
 
     //
     // WORKFLOW: Run pipeline
@@ -126,7 +130,9 @@ workflow NXF_AUTOSEQ {
         ch_pon_breakpoints,
         ch_known_fusions,
         ch_repeatmasker_annotations,
-        ch_gridss_config
+        ch_gridss_config,
+        ch_dbsnp_vcf,
+        ch_dbsnp_vcf_tbi
     )
 
     emit:
@@ -209,6 +215,10 @@ output {
                 return 'variants/somatic/merged'
             } else if (meta.file == 'vep_vcf' || meta.file == 'vep_tbi') {
                 return 'variants/somatic'
+            } else if (meta.file == 'germline_vcf' || meta.file == 'germline_tbi' || meta.file == 'germline_hc_bam') {
+                return 'variants/germline/haplotypecaller'
+            } else if (meta.file == 'germline_vep_vcf' || meta.file == 'germline_vep_tbi') {
+                return 'variants/germline/'
             } else if (meta.file == 'gripss_somatic_filtered_vcf' || meta.file == 'gripss_somatic_unfiltered_vcf') {
                 return 'svs/somatic/'
             } else if (meta.file == 'gripss_germline_filtered_vcf' || meta.file == 'gripss_germline_unfiltered_vcf') {

--- a/main.nf
+++ b/main.nf
@@ -33,8 +33,8 @@ params.ref_genome_fasta                 = getGenomeAttribute('fasta')
 params.ref_genome_fai                   = getGenomeAttribute('fai')
 params.ref_genome_dict                  = getGenomeAttribute('dict')
 params.bwamem2_index                    = getGenomeAttribute('bwamem2_index')
-params.dbsnp_vcf                       = getGenomeAttribute('dbsnp_vcf')
-params.dbsnp_vcf_tbi                   = getGenomeAttribute('dbsnp_vcf_tbi')
+params.dbsnp_vcf                        = getGenomeAttribute('dbsnp_vcf')
+params.dbsnp_vcf_tbi                    = getGenomeAttribute('dbsnp_vcf_tbi')
 params.germline_resource                = getGenomeAttribute('germline_resource')
 params.germline_resource_tbi            = getGenomeAttribute('germline_resource_tbi')
 params.sage_known_hotspots_somatic      = getGenomeAttribute('sage_known_hotspots_somatic')
@@ -79,8 +79,8 @@ workflow NXF_AUTOSEQ {
     ch_genome_fai    = params.ref_genome_fai    ? channel.fromPath(params.ref_genome_fai).map{ it -> [[id:'genome_fai'], it]}.collect() : channel.empty()
     ch_dict          = params.ref_genome_dict   ? channel.fromPath(params.ref_genome_dict).map{ it -> [[id:'genome_dict'], it]}.collect() : channel.empty()
     ch_bwamem2_index = params.bwamem2_index     ? channel.fromPath(params.bwamem2_index).map{ it -> [[id:'bwamem2_index'], it]}.collect() : channel.empty()
-    ch_dbsnp_vcf      = params.dbsnp_vcf        ? channel.fromPath(params.dbsnp_vcf).map{ it -> [[id:'dbsnp_vcf'], it]}.collect() : channel.empty()
-    ch_dbsnp_vcf_tbi  = params.dbsnp_vcf_tbi  ? channel.fromPath(params.dbsnp_vcf_tbi).map{ it -> [[id:'dbsnp_vcf_tbi'], it]}.collect() : channel.empty()
+    ch_dbsnp_vcf     = params.dbsnp_vcf        ? channel.fromPath(params.dbsnp_vcf).map{ it -> [[id:'dbsnp_vcf'], it]}.collect() : channel.empty()
+    ch_dbsnp_vcf_tbi = params.dbsnp_vcf_tbi  ? channel.fromPath(params.dbsnp_vcf_tbi).map{ it -> [[id:'dbsnp_vcf_tbi'], it]}.collect() : channel.empty()
 
     //
     ch_targets_bed             = params.targets_bed ? channel.fromPath(params.targets_bed).map{ it -> [[id:'targets_bed'], it]}.collect() : channel.empty()
@@ -98,12 +98,12 @@ workflow NXF_AUTOSEQ {
     ch_germline_resource_tbi       = params.germline_resource_tbi ? channel.fromPath(params.germline_resource_tbi).map{ it -> [[id:'germline_resource_tbi'], it]}.collect() : channel.empty()
 
     // GRIDSS-specific channels for SV calling
-    ch_genome_gridss_index = params.genome_gridss_index ? channel.fromPath(params.genome_gridss_index).map{ it -> [[id:'genome_gridss_index'], it]}.collect() : channel.empty()
-    ch_pon_breakends       = params.gridss_pon_breakends ? channel.fromPath(params.gridss_pon_breakends).map{ it -> [[id:'pon_breakends'], it]}.collect() : channel.empty()
-    ch_pon_breakpoints     = params.gridss_pon_breakpoints ? channel.fromPath(params.gridss_pon_breakpoints).map{ it -> [[id:'pon_breakpoints'], it]}.collect() : channel.empty()
-    ch_known_fusions       = params.gridss_known_fusions ? channel.fromPath(params.gridss_known_fusions).map{ it -> [[id:'known_fusions'], it]}.collect() : channel.empty()
+    ch_genome_gridss_index      = params.genome_gridss_index ? channel.fromPath(params.genome_gridss_index).map{ it -> [[id:'genome_gridss_index'], it]}.collect() : channel.empty()
+    ch_pon_breakends            = params.gridss_pon_breakends ? channel.fromPath(params.gridss_pon_breakends).map{ it -> [[id:'pon_breakends'], it]}.collect() : channel.empty()
+    ch_pon_breakpoints          = params.gridss_pon_breakpoints ? channel.fromPath(params.gridss_pon_breakpoints).map{ it -> [[id:'pon_breakpoints'], it]}.collect() : channel.empty()
+    ch_known_fusions            = params.gridss_known_fusions ? channel.fromPath(params.gridss_known_fusions).map{ it -> [[id:'known_fusions'], it]}.collect() : channel.empty()
     ch_repeatmasker_annotations = params.gridss_repeatmasker_annotations ? channel.fromPath(params.gridss_repeatmasker_annotations).map{ it -> [[id:'repeatmasker_annotations'], it]}.collect() : channel.empty()
-    ch_gridss_config         = params.gridss_config ? channel.fromPath(params.gridss_config).map{ it -> [[id: 'gridss_config'], it]}.collect() : channel.empty()
+    ch_gridss_config            = params.gridss_config ? channel.fromPath(params.gridss_config).map{ it -> [[id: 'gridss_config'], it]}.collect() : channel.empty()
 
     //
     // WORKFLOW: Run pipeline

--- a/nextflow.config
+++ b/nextflow.config
@@ -46,7 +46,7 @@ params {
     sage_min_tumor_qual      = 250
     sage_min_map_quality     = 20
 
-    ensemblvep_version       = "115"
+    ensemblvep_version       = 115
     vep_species              = "homo_sapiens"
     cancer_type              = 'PANCANCER' // shorthand code for the cancer project (e.g., 'CBC' for clinical breast cancer)
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -47,6 +47,7 @@ params {
     sage_min_map_quality     = 20
 
     ensemblvep_version       = "115"
+    vep_species              = "homo_sapiens"
     cancer_type              = 'PANCANCER' // shorthand code for the cancer project (e.g., 'CBC' for clinical breast cancer)
 
     // Boilerplate options

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -215,9 +215,9 @@
                     "default": 20
                 },
                 "ensemblvep_version": {
-                    "type": "string",
+                    "type": "integer",
                     "description": "Version of Ensembl VEP to use",
-                    "default": "115"
+                    "default": 115
                 },
                 "curation_ann": {
                     "type": "string",
@@ -265,6 +265,19 @@
                 "ensembl_vep_cache": {
                     "type": "string",
                     "description": "Path to Ensembl VEP cache directory"
+                },
+                "vep_species": {
+                    "type": "string",
+                    "default": "homo_sapiens",
+                    "description": "Species name for Ensembl VEP annotation"
+                },
+                "dbsnp_vcf": {
+                    "type": "string",
+                    "description": "Path to dbSNP VCF file for variant annotation"
+                },
+                "dbsnp_vcf_tbi": {
+                    "type": "string",
+                    "description": "Path to dbSNP VCF tabix index file"
                 }
             }
         },

--- a/subworkflows/local/call_germline_snvs/main.nf
+++ b/subworkflows/local/call_germline_snvs/main.nf
@@ -41,7 +41,6 @@ workflow GERMLINE_SNV_CALLING {
     emit:
     vcf     = GATK4_HAPLOTYPECALLER.out.vcf
     tbi     = GATK4_HAPLOTYPECALLER.out.tbi
-    bam     = GATK4_HAPLOTYPECALLER.out.bam
     vep_vcf = ENSEMBLVEP_VEP.out.vcf
     vep_tbi = ENSEMBLVEP_VEP.out.tbi
 

--- a/subworkflows/local/call_germline_snvs/main.nf
+++ b/subworkflows/local/call_germline_snvs/main.nf
@@ -2,21 +2,25 @@
 include { GATK4_HAPLOTYPECALLER     } from '../../../modules/nf-core/gatk4/haplotypecaller/main'
 include { ENSEMBLVEP_VEP            } from '../../../modules/nf-core/ensemblvep/vep/main'
 
-workflow CALL_GERMLINE_SNVS {
+workflow GERMLINE_SNV_CALLING {
     take:
-        ch_bam                  // [meta, bam, bai]
+        ch_input                  // [meta, bam, bai, intervals, dragstr_model]
         ch_genome_fasta         // [meta_ref, fasta]
         ch_genome_fai           // [meta_ref, fai]
         ch_dict                 // [meta_ref, dict]
         ch_vep_cache            // [meta_cache, cache_dir]
+        ch_dbsnp_vcf
+        ch_dbsnp_vcf_tbi
 
     main:
 
         GATK4_HAPLOTYPECALLER(
-            ch_bam,
+            ch_input,
             ch_genome_fasta,
             ch_genome_fai,
-            ch_dict
+            ch_dict,
+            ch_dbsnp_vcf,
+            ch_dbsnp_vcf_tbi
         )
 
         haplotypecaller_vcf = GATK4_HAPLOTYPECALLER.out.vcf
@@ -35,5 +39,10 @@ workflow CALL_GERMLINE_SNVS {
         )
 
     emit:
+    vcf     = GATK4_HAPLOTYPECALLER.out.vcf
+    tbi     = GATK4_HAPLOTYPECALLER.out.tbi
+    bam     = GATK4_HAPLOTYPECALLER.out.bam
     vep_vcf = ENSEMBLVEP_VEP.out.vcf
+    vep_tbi = ENSEMBLVEP_VEP.out.tbi
+
 }

--- a/subworkflows/local/call_germline_snvs/main.nf
+++ b/subworkflows/local/call_germline_snvs/main.nf
@@ -1,0 +1,39 @@
+
+include { GATK4_HAPLOTYPECALLER     } from '../../../modules/nf-core/gatk4/haplotypecaller/main'
+include { ENSEMBLVEP_VEP            } from '../../../modules/nf-core/ensemblvep/vep/main'
+
+workflow CALL_GERMLINE_SNVS {
+    take:
+        ch_bam                  // [meta, bam, bai]
+        ch_genome_fasta         // [meta_ref, fasta]
+        ch_genome_fai           // [meta_ref, fai]
+        ch_dict                 // [meta_ref, dict]
+        ch_vep_cache            // [meta_cache, cache_dir]
+
+    main:
+
+        GATK4_HAPLOTYPECALLER(
+            ch_bam,
+            ch_genome_fasta,
+            ch_genome_fai,
+            ch_dict
+        )
+
+        haplotypecaller_vcf = GATK4_HAPLOTYPECALLER.out.vcf
+            .map { meta, vcf ->
+                [meta, vcf, []]  // Add empty custom_extra_files for VEP
+            }
+
+        ENSEMBLVEP_VEP(
+            haplotypecaller_vcf,
+            params.genome,
+            params.vep_species,  // Assuming human genome; adjust as needed
+            params.ensemblvep_version,
+            ch_vep_cache.collect{it -> it[1]},
+            ch_genome_fasta,
+            []
+        )
+
+    emit:
+    vep_vcf = ENSEMBLVEP_VEP.out.vcf
+}

--- a/subworkflows/local/call_germline_snvs/main.nf
+++ b/subworkflows/local/call_germline_snvs/main.nf
@@ -4,7 +4,7 @@ include { ENSEMBLVEP_VEP            } from '../../../modules/nf-core/ensemblvep/
 
 workflow GERMLINE_SNV_CALLING {
     take:
-        ch_input                  // [meta, bam, bai, intervals, dragstr_model]
+        ch_input                // [meta, bam, bai, intervals, dragstr_model]
         ch_genome_fasta         // [meta_ref, fasta]
         ch_genome_fai           // [meta_ref, fai]
         ch_dict                 // [meta_ref, dict]

--- a/workflows/autoseq.nf
+++ b/workflows/autoseq.nf
@@ -19,6 +19,7 @@ include { READ_ALIGNMENT                                      } from '../subwork
 include { FASTQ_CREATE_UMI_CONSENSUS_FGBIO as UMI_PROCESSING  } from '../subworkflows/nf-core/fastq_create_umi_consensus_fgbio/main'
 include { BAM_QC_PICARD_SAMTOOLS  as ALIGNMENT_QC             } from '../subworkflows/local/bam_qc_picard_samtools/main.nf'
 include { SOMATIC_SNV_CALLING                                 } from '../subworkflows/local/call_somatic_snvs/main.nf'
+include { GERMLINE_SNV_CALLING                                } from '../subworkflows/local/call_germline_snvs/main.nf'
 include { CNV_CALLING                                         } from '../subworkflows/local/call_cnvs/main.nf'
 include { SVS_CALLING                                         } from '../subworkflows/local/call_svs/main.nf'
 /*
@@ -52,11 +53,13 @@ workflow AUTOSEQ {
     ch_known_fusions    // channel: known fusions for SV filtering
     ch_repeatmasker_annotations // channel: repeatmasker annotations for SV filtering
     ch_gridss_config   // path: optional GRIDSS config file
+    ch_dbsnp_vcf      // channel: optional dbSNP VCF for SNV annotation
+    ch_dbsnp_vcf_tbi  // channel: optional dbSNP VCF
 
     main:
 
-    ch_versions = Channel.empty()
-    ch_multiqc_files = Channel.empty()
+    ch_versions = channel.empty()
+    ch_multiqc_files = channel.empty()
 
     //
     // MODULE: Run FastQC
@@ -94,9 +97,9 @@ workflow AUTOSEQ {
                 return [meta.sample_name, [meta , reads]]
             }
             .groupTuple()
-            .map { sample_name, grouped_reads ->
-                def metas = grouped_reads.collect{it[0]}
-                def files = grouped_reads.collect{it[1]}.flatten()
+            .map { _sample_name, grouped_reads ->
+                def metas = grouped_reads.collect{it -> it[0]}
+                def files = grouped_reads.collect{it -> it[1]}.flatten()
                 return [metas[0], files]
             }
             .set { ch_input_reads }
@@ -137,7 +140,7 @@ workflow AUTOSEQ {
             ch_bwamem2_index
         )
 
-        ch_multiqc_files = ch_multiqc_files.mix(READ_ALIGNMENT.out.dedup_metrics.collect{it[1]}.ifEmpty([]))
+        ch_multiqc_files = ch_multiqc_files.mix(READ_ALIGNMENT.out.dedup_metrics.collect{it -> it[1]}.ifEmpty([]))
         ch_versions = ch_versions.mix(READ_ALIGNMENT.out.versions)
         ch_aligned_bam = READ_ALIGNMENT.out.dedup_bam
             .join(READ_ALIGNMENT.out.dedup_bai)
@@ -163,7 +166,7 @@ workflow AUTOSEQ {
 
     // Branch samples by tumor/normal
     ch_aligned_bam
-        .branch { meta, bam, bai ->
+        .branch { meta, _bam, _bai ->
             tumor: meta.sample_type == "tumor"
             normal: meta.sample_type == "normal"
         }
@@ -185,7 +188,7 @@ workflow AUTOSEQ {
     ch_input_paired = tumor_ch
         .join(normal_ch, by: 0)
         .combine(ch_interval_list_slopped20)
-        .map { case_id, tumor_meta, tumor_bam, tumor_bai, normal_meta, normal_bam, normal_bai, meta_intervals, intervals_file ->
+        .map { case_id, tumor_meta, tumor_bam, tumor_bai, normal_meta, normal_bam, normal_bai, _meta_intervals, intervals_file ->
             // Create comprehensive meta map
             def meta = [
                 id: case_id,
@@ -224,6 +227,27 @@ workflow AUTOSEQ {
     ch_versions = ch_versions.mix(SOMATIC_SNV_CALLING.out.versions)
 
     //
+    // MODULE: GERMLINE Variant Calling
+    //
+
+    ch_germline_input = normal_ch
+        .combine(ch_interval_list_slopped20)
+        .map { _case_id, meta, bam, bai, _meta_intervals, intervals ->
+            [meta, bam, bai, intervals, []]
+        }
+
+
+    GERMLINE_SNV_CALLING(
+        ch_germline_input,  // normal samples only
+        ch_genome_fasta,
+        ch_genome_fai,
+        ch_dict,
+        ch_ensembl_vep_cache,
+        ch_dbsnp_vcf,
+        ch_dbsnp_vcf_tbi
+    )
+
+    //
     // MODULE: CNV Calling
     //
 
@@ -255,7 +279,7 @@ workflow AUTOSEQ {
     //
     // Collate and save software versions
     //
-    def topic_versions = Channel.topic("versions")
+    def topic_versions = channel.topic("versions")
         .distinct()
         .branch { entry ->
             versions_file: entry instanceof Path
@@ -285,14 +309,14 @@ workflow AUTOSEQ {
     //
     // MODULE: MultiQC
     //
-    ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.zip.collect{it[1]}.ifEmpty([]))
-    ch_multiqc_files = ch_multiqc_files.mix(FASTP.out.json.collect{it[1]}.ifEmpty([]))
-    ch_multiqc_files = ch_multiqc_files.mix(ALIGNMENT_QC.out.multiple_metrics.collect{it[1]}.ifEmpty([]))
-    ch_multiqc_files = ch_multiqc_files.mix(ALIGNMENT_QC.out.hs_metrics.collect{it[1]}.ifEmpty([]))
-    ch_multiqc_files = ch_multiqc_files.mix(ALIGNMENT_QC.out.flagstat.collect{it[1]}.ifEmpty([]))
+    ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.zip.collect{it -> it[1]}.ifEmpty([]))
+    ch_multiqc_files = ch_multiqc_files.mix(FASTP.out.json.collect{it -> it[1]}.ifEmpty([]))
+    ch_multiqc_files = ch_multiqc_files.mix(ALIGNMENT_QC.out.multiple_metrics.collect{it -> it[1]}.ifEmpty([]))
+    ch_multiqc_files = ch_multiqc_files.mix(ALIGNMENT_QC.out.hs_metrics.collect{it -> it[1]}.ifEmpty([]))
+    ch_multiqc_files = ch_multiqc_files.mix(ALIGNMENT_QC.out.flagstat.collect{it -> it[1]}.ifEmpty([]))
 
 
-    ch_multiqc_config        = Channel.fromPath(
+    ch_multiqc_config        = channel.fromPath(
         "$projectDir/assets/multiqc_config.yml", checkIfExists: true)
     ch_multiqc_custom_config = params.multiqc_config ?
         channel.fromPath(params.multiqc_config, checkIfExists: true) :
@@ -331,7 +355,7 @@ workflow AUTOSEQ {
 
     // Prepare final output channel
 
-    autoseq_output = Channel
+    autoseq_output = channel
         .empty()
         .mix(
             ch_aligned_bam.map { meta, bam, _bai -> [ meta + [file: "bam"], bam] },
@@ -356,6 +380,11 @@ workflow AUTOSEQ {
             SOMATIC_SNV_CALLING.out.somatic_tbi.map { meta, somatic_tbi -> [ meta + [file: "somatic_tbi"], somatic_tbi] },
             SOMATIC_SNV_CALLING.out.vep_vcf.map { meta, vep_vcf -> [ meta + [file: "vep_vcf"], vep_vcf] },
             SOMATIC_SNV_CALLING.out.vep_tbi.map { meta, vep_tbi -> [ meta + [file: "vep_tbi"], vep_tbi] },
+            GERMLINE_SNV_CALLING.out.vcf.map { meta, vcf -> [ meta + [file: "germline_vcf"], vcf] },
+            GERMLINE_SNV_CALLING.out.tbi.map { meta, tbi -> [ meta + [file: "germline_tbi"], tbi] },
+            GERMLINE_SNV_CALLING.out.bam.map { meta, bam -> [ meta + [file: "germline_hc_bam"], bam] },
+            GERMLINE_SNV_CALLING.out.vep_vcf.map { meta, vep_vcf -> [ meta + [file: "germline_vep_vcf"], vep_vcf] },
+            GERMLINE_SNV_CALLING.out.vep_tbi.map { meta, vep_tbi -> [ meta + [file: "germline_vep_tbi"], vep_tbi] },
             SVS_CALLING.out.gripss_somatic_filtered_vcf.map { meta, vcf, tbi -> [ meta + [file: "gripss_somatic_filtered_vcf"], [vcf, tbi]] },
             SVS_CALLING.out.gripss_somatic_unfiltered_vcf.map { meta, vcf, tbi -> [ meta + [file: "gripss_somatic_unfiltered_vcf"], [vcf, tbi]] },
             SVS_CALLING.out.gripss_germline_filtered_vcf.map { meta, vcf, tbi -> [ meta + [file: "gripss_germline_filtered_vcf"], [vcf, tbi]] },

--- a/workflows/autoseq.nf
+++ b/workflows/autoseq.nf
@@ -382,7 +382,6 @@ workflow AUTOSEQ {
             SOMATIC_SNV_CALLING.out.vep_tbi.map { meta, vep_tbi -> [ meta + [file: "vep_tbi"], vep_tbi] },
             GERMLINE_SNV_CALLING.out.vcf.map { meta, vcf -> [ meta + [file: "germline_vcf"], vcf] },
             GERMLINE_SNV_CALLING.out.tbi.map { meta, tbi -> [ meta + [file: "germline_tbi"], tbi] },
-            GERMLINE_SNV_CALLING.out.bam.map { meta, bam -> [ meta + [file: "germline_hc_bam"], bam] },
             GERMLINE_SNV_CALLING.out.vep_vcf.map { meta, vep_vcf -> [ meta + [file: "germline_vep_vcf"], vep_vcf] },
             GERMLINE_SNV_CALLING.out.vep_tbi.map { meta, vep_tbi -> [ meta + [file: "germline_vep_tbi"], vep_tbi] },
             SVS_CALLING.out.gripss_somatic_filtered_vcf.map { meta, vcf, tbi -> [ meta + [file: "gripss_somatic_filtered_vcf"], [vcf, tbi]] },

--- a/workflows/autoseq.nf
+++ b/workflows/autoseq.nf
@@ -85,7 +85,7 @@ workflow AUTOSEQ {
     ch_input_reads = FASTP.out.reads
 
     //
-    // MODULE: ALIGNMENT
+    // SUBWORKFLOW: ALIGNMENT
     //
 
     if (params.umi_structure) {
@@ -147,7 +147,7 @@ workflow AUTOSEQ {
     }
 
     //
-    // MODULE: QC of aligned BAM files
+    // SUBWORKFLOW: QC of aligned BAM files
     //
 
     ALIGNMENT_QC(
@@ -161,7 +161,7 @@ workflow AUTOSEQ {
     ch_versions = ch_versions.mix(ALIGNMENT_QC.out.versions)
 
     //
-    // MODULE: Somatic SNV and INDELs Calling
+    // SUBWORKFLOW: Somatic SNV and INDELs Calling
     //
 
     // Branch samples by tumor/normal
@@ -227,7 +227,7 @@ workflow AUTOSEQ {
     ch_versions = ch_versions.mix(SOMATIC_SNV_CALLING.out.versions)
 
     //
-    // MODULE: GERMLINE Variant Calling
+    // SUBWORKFLOW: GERMLINE Variant Calling
     //
 
     ch_germline_input = normal_ch
@@ -248,7 +248,7 @@ workflow AUTOSEQ {
     )
 
     //
-    // MODULE: CNV Calling
+    // SUBWORKFLOW: CNV Calling
     //
 
     CNV_CALLING(
@@ -258,7 +258,7 @@ workflow AUTOSEQ {
     )
 
     //
-    // MODULE: SV Calling
+    // SUBWORKFLOW: SV Calling
     //
 
     SVS_CALLING(


### PR DESCRIPTION
## Description 

- #14 
- created a subworkflow for germline variant calling 
GATK4-Haplotypecaller --> ENSEMBLVEP --> GEMRLINE VCF
- Fixed issues,
  - code refactor `Channel` to `channel` 
  - pipeline schema lint - ensemblvep version type
  - Removed `--filter_common` param from somatic vep annotation config 

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/autoseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/autoseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
