### PR TITLE
fix: Add PR `write` permissions for `add_pr_checklist_comment` action

### DIFF
--- a/.github/workflows/add_pr_checklist_comment.yml
+++ b/.github/workflows/add_pr_checklist_comment.yml
@@ -4,6 +4,9 @@ on:
     types:
       - opened
 
+permissions:
+  pull-requests: write
+
 jobs:
   add_pr_checklist_comment:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Initial release of nf-core/autoseq, created with the [nf-core](https://nf-co.re/
 
 ### `Fixed`
 
+- [ #22 ](https://github.com/genomic-medicine-sweden/nf-autoseq/pull/22) Added PR `write` permissions for `add_pr_checklist_comment` action.
+
 ### `Dependencies`
 
 ### `Deprecated`


### PR DESCRIPTION
### Fixed

- Added PR `write` permissions for `add_pr_checklist_comment` action.