### PR TITLE
test: add nf-test for gridss/extract_overlapping_fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Initial release of genomic-medicine-sweden/autoseq, created with the [nf-core](h
 - [ #16 ](https://github.com/imsarath/nf-autoseq/pull/16) Added subworkflow for germline variant calling - GATK4 haplotypecaller and minor bug fixes
 - [ #19 ](https://github.com/imsarath/nf-autoseq/pull/19) Repo setup for Genome Medicine Sweden Org
 - [ #21 ](https://github.com/genomic-medicine-sweden/nf-autoseq/pull/21) Added sub-workflow for tumor biomarker profiling - purecn-run and typeDPYD
+- [ #42 ](https://github.com/genomic-medicine-sweden/autoseq/pull/42) Added nf-test for `gridss/extract_overlapping_fragments` module.
 
 ### `Changed`
 

--- a/modules/local/gridss/extract_overlapping_fragments/tests/main.nf.test
+++ b/modules/local/gridss/extract_overlapping_fragments/tests/main.nf.test
@@ -30,9 +30,6 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                // BAM contents are sorted/compressed and md5-stable for the same input, so snapshotting is safe.
-                // Use findAll to collect every emit:* topic version channel — keeps the assertion stable when
-                // new tools are added to the module's output block.
                 { assert snapshot(
                     process.out.gridss_targeted_bam,
                     process.out.findAll { key, val -> key.startsWith("versions") }

--- a/modules/local/gridss/extract_overlapping_fragments/tests/main.nf.test
+++ b/modules/local/gridss/extract_overlapping_fragments/tests/main.nf.test
@@ -1,0 +1,75 @@
+nextflow_process {
+
+    name "Test Process GRIDSS_EXTRACT_OVERLAPPING_FRAGMENTS"
+    script "../main.nf"
+    process "GRIDSS_EXTRACT_OVERLAPPING_FRAGMENTS"
+
+    tag "modules"
+    tag "modules_local"
+    tag "gridss"
+    tag "gridss/extract_overlapping_fragments"
+
+    test("targeted_bam") {
+
+        when {
+            process {
+                """
+                input[0] = channel.of([
+                    [ id:'test_sample' ],
+                    file(params.pipelines_testdata_base_path + 'testdata/bam/1234T_dedup.bam', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'testdata/bam/1234T_dedup.bai', checkIfExists: true)
+                ])
+                input[1] = channel.of([
+                    [ id:'target_regions' ],
+                    file(params.pipelines_testdata_base_path + 'testdata/gridss/test_target.bed', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                // BAM contents are sorted/compressed and md5-stable for the same input, so snapshotting is safe.
+                // Use findAll to collect every emit:* topic version channel — keeps the assertion stable when
+                // new tools are added to the module's output block.
+                { assert snapshot(
+                    process.out.gridss_targeted_bam,
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                ).match() }
+            )
+        }
+    }
+
+    test("targeted_bam - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = channel.of([
+                    [ id:'test_sample' ],
+                    file(params.pipelines_testdata_base_path + 'testdata/bam/1234T_dedup.bam', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'testdata/bam/1234T_dedup.bai', checkIfExists: true)
+                ])
+                input[1] = channel.of([
+                    [ id:'target_regions' ],
+                    file(params.pipelines_testdata_base_path + 'testdata/gridss/test_target.bed', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.gridss_targeted_bam,
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                ).match() }
+            )
+        }
+    }
+
+}

--- a/modules/local/gridss/extract_overlapping_fragments/tests/main.nf.test.snap
+++ b/modules/local/gridss/extract_overlapping_fragments/tests/main.nf.test.snap
@@ -1,0 +1,70 @@
+{
+    "targeted_bam - stub": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "test_sample.gridss.targeted.bam:md5,d41d8cd98f00b204e9800998ecf8427e",
+                    "test_sample.gridss.targeted.bam.bai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            {
+                "versions_gridss": [
+                    [
+                        "GRIDSS_EXTRACT_OVERLAPPING_FRAGMENTS",
+                        "gridss",
+                        "2.13.2"
+                    ]
+                ],
+                "versions_samtools": [
+                    [
+                        "GRIDSS_EXTRACT_OVERLAPPING_FRAGMENTS",
+                        "samtools",
+                        "1.21"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-26T11:19:48.18588574",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
+    },
+    "targeted_bam": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "test_sample.gridss.targeted.bam:md5,517d42eca0bba96012a0c7ed7e57db9f",
+                    "test_sample.gridss.targeted.bam.bai:md5,0666f7057799d742a155b72db3c692a0"
+                ]
+            ],
+            {
+                "versions_gridss": [
+                    [
+                        "GRIDSS_EXTRACT_OVERLAPPING_FRAGMENTS",
+                        "gridss",
+                        "2.13.2"
+                    ]
+                ],
+                "versions_samtools": [
+                    [
+                        "GRIDSS_EXTRACT_OVERLAPPING_FRAGMENTS",
+                        "samtools",
+                        "1.21"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-26T11:19:40.438741961",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
+    }
+}


### PR DESCRIPTION
Part of #34  

### Added

- nf-test for `modules/local/gridss/extract_overlapping_fragments` covering both a real run and a stub fallback.