### PR TITLE
feat: add prepare_references subworkflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Initial release of genomic-medicine-sweden/autoseq, created with the [nf-core](h
 - [ #40 ](https://github.com/genomic-medicine-sweden/autoseq/pull/40) Added nf-test for the `ANNOTATE_CNVS` local module covering somatic, germline, and stub cases.
 - [ #42 ](https://github.com/genomic-medicine-sweden/autoseq/pull/42) Added nf-test for `gridss/extract_overlapping_fragments` module.
 - [ #43 ](https://github.com/genomic-medicine-sweden/autoseq/pull/43) Added nf-test for the `gridss/preprocess` local module covering a targeted BAM scenario and stub case.
+- [ #50 ](https://github.com/genomic-medicine-sweden/autoseq/pull/50) Added `PREPARE_REFERENCES` subworkflow to build the BWA-MEM2 index and untar the VEP cache, GRIDSS index and HMF ensembl_data references, with nf-test coverage.
 
 ### `Changed`
 

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -74,6 +74,9 @@ Other options specific to this pipeline.
 | `minpurity` | Minimum tumour purity estimate accepted by PureCN; solutions below this threshold are discarded | `number` | 0.05 |  |  |
 | `purecn_error` | Expected sequencing error rate passed to PureCN for modelling variant allele frequencies | `number` | 0.0005 |  |  |
 | `minaf` | Minimum variant allele frequency for a SNV to be considered by PureCN | `number` | 0.01 |  |  |
+| `ensembl_vep_cache_tar` | Path to Ensembl VEP cache tar archive | `string` |  |  |  |
+| `gridss_index_tar` | Path to GRIDSS index tar archive | `string` |  |  |  |
+| `hmf_ensembl_data_tar` | Path to HMF Ensembl data tar archive | `string` |  |  |  |
 
 ## Generic options
 

--- a/main.nf
+++ b/main.nf
@@ -18,6 +18,7 @@ include { PIPELINE_INITIALISATION } from './subworkflows/local/utils_nfcore_auto
 include { PIPELINE_COMPLETION     } from './subworkflows/local/utils_nfcore_autoseq_pipeline'
 include { getGenomeAttribute      } from './subworkflows/local/utils_nfcore_autoseq_pipeline'
 include { getPanelsAttribute      } from './subworkflows/local/utils_nfcore_autoseq_pipeline'
+include { PREPARE_REFERENCES      } from './subworkflows/local/prepare_references/main'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -74,13 +75,31 @@ workflow NXF_AUTOSEQ {
 
     main:
 
+    // Minimal reference preparation workflow
+    PREPARE_REFERENCES (
+        params.ref_genome_fasta,
+        params.bwamem2_index,
+        params.ensembl_vep_cache,
+        params.ensembl_vep_cache_tar,
+        params.genome_gridss_index,
+        params.gridss_index_tar,
+        params.ensembl_data_resources,
+        params.hmf_ensembl_data_tar
+    )
+    .set{ch_references}
+
+
     //
     // Initialise channels for reference genome
     //
-    ch_genome_fasta  = params.ref_genome_fasta  ? channel.fromPath(params.ref_genome_fasta).map{ it -> [[id:'genome_fasta'], it]}.collect() : channel.empty()
+    ch_genome_fasta            = ch_references.genome_fasta
+    ch_bwamem2_index           = ch_references.bwamem2_index
+    ch_ensembl_vep_cache       = ch_references.vep_cache
+    ch_ensembl_data_resources  = ch_references.hmf_ensembl_data
+    ch_genome_gridss_index     = ch_references.gridss_index
+
     ch_genome_fai    = params.ref_genome_fai    ? channel.fromPath(params.ref_genome_fai).map{ it -> [[id:'genome_fai'], it]}.collect() : channel.empty()
     ch_dict          = params.ref_genome_dict   ? channel.fromPath(params.ref_genome_dict).map{ it -> [[id:'genome_dict'], it]}.collect() : channel.empty()
-    ch_bwamem2_index = params.bwamem2_index     ? channel.fromPath(params.bwamem2_index).map{ it -> [[id:'bwamem2_index'], it]}.collect() : channel.empty()
     ch_dbsnp_vcf     = params.dbsnp_vcf        ? channel.fromPath(params.dbsnp_vcf).map{ it -> [[id:'dbsnp_vcf'], it]}.collect() : channel.empty()
     ch_dbsnp_vcf_tbi = params.dbsnp_vcf_tbi  ? channel.fromPath(params.dbsnp_vcf_tbi).map{ it -> [[id:'dbsnp_vcf_tbi'], it]}.collect() : channel.empty()
 
@@ -88,19 +107,16 @@ workflow NXF_AUTOSEQ {
     ch_targets_bed             = params.targets_bed ? channel.fromPath(params.targets_bed).map{ it -> [[id:'targets_bed'], it]}.collect() : channel.empty()
     ch_interval_list_slopped20 = params.interval_list_slopped20 ? channel.fromPath(params.interval_list_slopped20).map{ it -> [[id:'interval_list_slopped20'], it]}.collect() : channel.empty()
     ch_jumble_ref              = params.jumble_ref ? channel.fromPath(params.jumble_ref).map{ it -> [[id:'jumble_ref'], it]}.collect() : channel.empty()
-    ch_ensembl_vep_cache       = params.ensembl_vep_cache ? channel.fromPath(params.ensembl_vep_cache).map{ it -> [[id:'ensembl_vep_cache'], it]}.collect() : channel.empty()
 
     //
     ch_sage_known_hotspots_somatic = params.sage_known_hotspots_somatic ? channel.fromPath(params.sage_known_hotspots_somatic).map{ it -> [[id:'sage_known_hotspots_somatic'], it]}.collect() : channel.empty()
     ch_sage_highconf_regions       = params.sage_highconf_regions ? channel.fromPath(params.sage_highconf_regions).map{ it -> [[id:'sage_highconf_regions'], it]}.collect() : channel.empty()
     ch_sage_pon                    = params.sage_pon ? channel.fromPath(params.sage_pon).map{ it -> [[id:'sage_pon'], it]}.collect() : channel.empty()
-    ch_ensembl_data_resources      = params.ensembl_data_resources ? channel.fromPath(params.ensembl_data_resources).map{ it -> [[id:'ensembl_data_resources'], it]}.collect() : channel.empty()
     ch_curation_ann                = params.curation_ann ? channel.fromPath(params.curation_ann).map{ it -> [[id:'curation_ann'], it]}.collect() : channel.empty()
     ch_germline_resource           = params.germline_resource ? channel.fromPath(params.germline_resource).map{ it -> [[id:'germline_resource'], it]}.collect() : channel.empty()
     ch_germline_resource_tbi       = params.germline_resource_tbi ? channel.fromPath(params.germline_resource_tbi).map{ it -> [[id:'germline_resource_tbi'], it]}.collect() : channel.empty()
 
     // GRIDSS-specific channels for SV calling
-    ch_genome_gridss_index      = params.genome_gridss_index ? channel.fromPath(params.genome_gridss_index).map{ it -> [[id:'genome_gridss_index'], it]}.collect() : channel.empty()
     ch_pon_breakends            = params.gridss_pon_breakends ? channel.fromPath(params.gridss_pon_breakends).map{ it -> [[id:'pon_breakends'], it]}.collect() : channel.empty()
     ch_pon_breakpoints          = params.gridss_pon_breakpoints ? channel.fromPath(params.gridss_pon_breakpoints).map{ it -> [[id:'pon_breakpoints'], it]}.collect() : channel.empty()
     ch_known_fusions            = params.gridss_known_fusions ? channel.fromPath(params.gridss_known_fusions).map{ it -> [[id:'known_fusions'], it]}.collect() : channel.empty()

--- a/main.nf
+++ b/main.nf
@@ -76,17 +76,16 @@ workflow NXF_AUTOSEQ {
     main:
 
     // Minimal reference preparation workflow
-    PREPARE_REFERENCES (
-        params.ref_genome_fasta,
-        params.bwamem2_index,
-        params.ensembl_vep_cache,
-        params.ensembl_vep_cache_tar,
-        params.genome_gridss_index,
-        params.gridss_index_tar,
-        params.ensembl_data_resources,
-        params.hmf_ensembl_data_tar
-    )
-    .set{ch_references}
+    def ch_references = PREPARE_REFERENCES (
+                            params.ref_genome_fasta,
+                            params.bwamem2_index,
+                            params.ensembl_vep_cache,
+                            params.ensembl_vep_cache_tar,
+                            params.genome_gridss_index,
+                            params.gridss_index_tar,
+                            params.ensembl_data_resources,
+                            params.hmf_ensembl_data_tar
+                        )
 
 
     //

--- a/modules.json
+++ b/modules.json
@@ -155,6 +155,11 @@
                         "git_sha": "f2cfcf9d3f6a2d123e6c44aefa788aa232204a7a",
                         "installed_by": ["modules"]
                     },
+                    "untar": {
+                        "branch": "master",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
+                        "installed_by": ["modules"]
+                    },
                     "vt/decompose": {
                         "branch": "master",
                         "git_sha": "ddb0d667cf6cdee3bab9497241de4bbf6b88d8cc",

--- a/modules/nf-core/untar/environment.yml
+++ b/modules/nf-core/untar/environment.yml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - conda-forge::coreutils=9.5
+  - conda-forge::grep=3.11
+  - conda-forge::gzip=1.13
+  - conda-forge::lbzip2=2.5
+  - conda-forge::sed=4.8
+  - conda-forge::tar=1.34

--- a/modules/nf-core/untar/main.nf
+++ b/modules/nf-core/untar/main.nf
@@ -1,0 +1,75 @@
+process UNTAR {
+    tag "${archive}"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/52/52ccce28d2ab928ab862e25aae26314d69c8e38bd41ca9431c67ef05221348aa/data'
+        : 'community.wave.seqera.io/library/coreutils_grep_gzip_lbzip2_pruned:838ba80435a629f8'}"
+
+    input:
+    tuple val(meta), path(archive)
+
+    output:
+    tuple val(meta), path("${prefix}"), emit: untar
+    tuple val("${task.process}"), val('untar'), eval('tar --version 2>&1 | head -1 | sed "s/tar (GNU tar) //; s/ Copyright.*//"'), emit: versions_untar, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def args2 = task.ext.args2 ?: ''
+    prefix = task.ext.prefix ?: (meta.id ? "${meta.id}" : archive.baseName.toString().replaceFirst(/\.tar$/, ""))
+
+    """
+    mkdir ${prefix}
+
+    ## Ensures --strip-components only applied when top level of tar contents is a directory
+    ## If just files or multiple directories, place all in prefix
+    if [[ \$(tar -taf ${archive} | grep -o -P "^.*?\\/" | uniq | wc -l) -eq 1 ]]; then
+        tar \\
+            -C ${prefix} --strip-components 1 \\
+            -xavf \\
+            ${args} \\
+            ${archive} \\
+            ${args2}
+    else
+        tar \\
+            -C ${prefix} \\
+            -xavf \\
+            ${args} \\
+            ${archive} \\
+            ${args2}
+    fi
+
+    """
+
+    stub:
+    prefix = task.ext.prefix ?: (meta.id ? "${meta.id}" : archive.toString().replaceFirst(/\.[^\.]+(.gz)?$/, ""))
+    """
+    mkdir ${prefix}
+    ## Dry-run untaring the archive to get the files and place all in prefix
+    if [[ \$(tar -taf ${archive} | grep -o -P "^.*?\\/" | uniq | wc -l) -eq 1 ]]; then
+        for i in `tar -tf ${archive}`;
+        do
+            if [[ \$(echo "\${i}" | grep -E "/\$") == "" ]];
+            then
+                touch \${i}
+            else
+                mkdir -p \${i}
+            fi
+        done
+    else
+        for i in `tar -tf ${archive}`;
+        do
+            if [[ \$(echo "\${i}" | grep -E "/\$") == "" ]];
+            then
+                touch ${prefix}/\${i}
+            else
+                mkdir -p ${prefix}/\${i}
+            fi
+        done
+    fi
+    """
+}

--- a/modules/nf-core/untar/meta.yml
+++ b/modules/nf-core/untar/meta.yml
@@ -1,0 +1,73 @@
+name: untar
+description: Extract files from tar, tar.gz, tar.bz2, tar.xz archives
+keywords:
+  - untar
+  - uncompress
+  - extract
+tools:
+  - untar:
+      description: |
+        Extract tar, tar.gz, tar.bz2, tar.xz files.
+      documentation: https://www.gnu.org/software/tar/manual/
+      licence: ["GPL-3.0-or-later"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - archive:
+        type: file
+        description: File to be untarred
+        pattern: "*.{tar,tar.gz,tar.bz2,tar.xz}"
+        ontologies:
+          - edam: http://edamontology.org/format_3981 # TAR format
+          - edam: http://edamontology.org/format_3989 # GZIP format
+output:
+  untar:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+          pattern: "*/"
+      - ${prefix}:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+          pattern: "*/"
+  versions_untar:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - untar:
+          type: string
+          description: The name of the tool
+      - tar --version 2>&1 | head -1 | sed "s/tar (GNU tar) //; s/ Copyright.*//":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - untar:
+          type: string
+          description: The name of the tool
+      - tar --version 2>&1 | head -1 | sed "s/tar (GNU tar) //; s/ Copyright.*//":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+authors:
+  - "@joseespinosa"
+  - "@drpatelh"
+  - "@matthdsm"
+  - "@jfy133"
+maintainers:
+  - "@joseespinosa"
+  - "@drpatelh"
+  - "@matthdsm"
+  - "@jfy133"

--- a/modules/nf-core/untar/tests/main.nf.test
+++ b/modules/nf-core/untar/tests/main.nf.test
@@ -1,0 +1,97 @@
+nextflow_process {
+
+    name "Test Process UNTAR"
+    script "../main.nf"
+    process "UNTAR"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "untar"
+
+    test("test_untar") {
+
+        when {
+            process {
+                """
+                input[0] = [ [], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/db/kraken2.tar.gz', checkIfExists: true) ]
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(
+                    process.out.untar,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() },
+            )
+        }
+    }
+
+    test("test_untar_onlyfiles") {
+
+        when {
+            process {
+                """
+                input[0] = [ [], file(params.modules_testdata_base_path + 'generic/tar/hello.tar.gz', checkIfExists: true) ]
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(
+                    process.out.untar,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() },
+            )
+        }
+    }
+
+    test("test_untar - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [ [], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/db/kraken2.tar.gz', checkIfExists: true) ]
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(
+                    process.out.untar,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() },
+            )
+        }
+    }
+
+    test("test_untar_onlyfiles - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [ [], file(params.modules_testdata_base_path + 'generic/tar/hello.tar.gz', checkIfExists: true) ]
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(
+                    process.out.untar,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() },
+            )
+        }
+    }
+}

--- a/modules/nf-core/untar/tests/main.nf.test.snap
+++ b/modules/nf-core/untar/tests/main.nf.test.snap
@@ -1,0 +1,118 @@
+{
+    "test_untar_onlyfiles": {
+        "content": [
+            [
+                [
+                    [
+                        
+                    ],
+                    [
+                        "hello.txt:md5,e59ff97941044f85df5297e1c302d260"
+                    ]
+                ]
+            ],
+            {
+                "versions_untar": [
+                    [
+                        "UNTAR",
+                        "untar",
+                        "1.34"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-28T17:49:32.000491"
+    },
+    "test_untar_onlyfiles - stub": {
+        "content": [
+            [
+                [
+                    [
+                        
+                    ],
+                    [
+                        "hello.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ]
+            ],
+            {
+                "versions_untar": [
+                    [
+                        "UNTAR",
+                        "untar",
+                        "1.34"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-28T17:49:58.812479"
+    },
+    "test_untar - stub": {
+        "content": [
+            [
+                [
+                    [
+                        
+                    ],
+                    [
+                        "hash.k2d:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "opts.k2d:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "taxo.k2d:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ]
+            ],
+            {
+                "versions_untar": [
+                    [
+                        "UNTAR",
+                        "untar",
+                        "1.34"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-28T17:49:48.119456"
+    },
+    "test_untar": {
+        "content": [
+            [
+                [
+                    [
+                        
+                    ],
+                    [
+                        "hash.k2d:md5,8b8598468f54a7087c203ad0190555d9",
+                        "opts.k2d:md5,a033d00cf6759407010b21700938f543",
+                        "taxo.k2d:md5,094d5891cdccf2f1468088855c214b2c"
+                    ]
+                ]
+            ],
+            {
+                "versions_untar": [
+                    [
+                        "UNTAR",
+                        "untar",
+                        "1.34"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-28T17:49:17.252494"
+    }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -56,6 +56,11 @@ params {
     minpurity                = 0.05
     purecn_error             = 0.0005
 
+    // tar archive
+    ensembl_vep_cache_tar    = null
+    gridss_index_tar         = null
+    hmf_ensembl_data_tar     = null
+
     // Boilerplate options
     outdir                       = './results'
     publish_dir_mode             = 'copy'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -297,6 +297,18 @@
                     "type": "number",
                     "default": 0.01,
                     "description": "Minimum variant allele frequency for a SNV to be considered by PureCN"
+                },
+                "ensembl_vep_cache_tar": {
+                    "type": "string",
+                    "description": "Path to Ensembl VEP cache tar archive"
+                },
+                "gridss_index_tar": {
+                    "type": "string",
+                    "description": "Path to GRIDSS index tar archive"
+                },
+                "hmf_ensembl_data_tar": {
+                    "type": "string",
+                    "description": "Path to HMF Ensembl data tar archive"
                 }
             }
         },

--- a/subworkflows/local/prepare_references/main.nf
+++ b/subworkflows/local/prepare_references/main.nf
@@ -1,0 +1,39 @@
+include { BWAMEM2_INDEX                   } from '../../../modules/nf-core/bwamem2/index/main'
+include { UNTAR as UNTAR_VEP_CACHE        } from '../../../modules/nf-core/untar/main'
+include { UNTAR as UNTAR_GRIDSS_INDEX     } from '../../../modules/nf-core/untar/main'
+include { UNTAR as UNTAR_HMF_ENSEMBL_DATA } from '../../../modules/nf-core/untar/main'
+
+workflow PREPARE_REFERENCES {
+
+    take:
+    ch_genome_fasta          // channel: [ val(meta), path(fasta) ]        genome FASTA to build the BWA-MEM2 index from
+    ch_vep_cache_tar         // channel: [ val(meta), path(archive) ]      VEP cache tar archive
+    ch_gridss_index_tar      // channel: [ val(meta), path(archive) ]      GRIDSS index tar archive
+    ch_hmf_ensembl_data_tar  // channel: [ val(meta), path(archive) ]      HMF ensembl_data tar archive
+
+    main:
+
+    def ch_versions = channel.empty()
+
+    //
+    // MODULE: Build the BWA-MEM2 index on the fly from the genome FASTA
+    //
+    BWAMEM2_INDEX ( ch_genome_fasta )
+    ch_versions = ch_versions.mix(BWAMEM2_INDEX.out.versions)
+
+    //
+    // MODULE: Untar directory-type references
+    //
+    UNTAR_VEP_CACHE ( ch_vep_cache_tar )
+
+    UNTAR_GRIDSS_INDEX ( ch_gridss_index_tar )
+
+    UNTAR_HMF_ENSEMBL_DATA ( ch_hmf_ensembl_data_tar )
+
+    emit:
+    bwamem2_index    = BWAMEM2_INDEX.out.index             // channel: [ val(meta), path(index) ]
+    vep_cache        = UNTAR_VEP_CACHE.out.untar           // channel: [ val(meta), path(dir) ]
+    gridss_index     = UNTAR_GRIDSS_INDEX.out.untar        // channel: [ val(meta), path(dir) ]
+    hmf_ensembl_data = UNTAR_HMF_ENSEMBL_DATA.out.untar    // channel: [ val(meta), path(dir) ]
+    versions         = ch_versions                         // channel: [ path(versions.yml) ]
+}

--- a/subworkflows/local/prepare_references/main.nf
+++ b/subworkflows/local/prepare_references/main.nf
@@ -6,14 +6,14 @@ include { UNTAR as UNTAR_HMF_ENSEMBL_DATA } from '../../../modules/nf-core/untar
 workflow PREPARE_REFERENCES {
 
     take:
-    val_genome_fasta            // string: path to genome FASTA to build the BWA-MEM2 index from
-    val_bwamem2_index           // string: path to BWA-MEM2 index from param
-    val_ensembl_vep_cache       // string: path to Ensembl VEP cache from param
-    val_ensembl_vep_cache_tar   // string: path to VEP cache tar archive
-    val_gridss_index            // string: path to GRIDSS index from param
-    val_gridss_index_tar        // string: path to GRIDSS index tar archive
-    val_hmf_ensembl_data        // string: path to HMF ensembl_data from param
-    val_hmf_ensembl_data_tar    // string: path to HMF ensembl_data tar archive
+    val_genome_fasta            // string: [mandatory] path to reference genome FASTA
+    val_bwamem2_index          // string: [optional] path to  pre-built BWA-MEM2 index directory
+    val_ensembl_vep_cache      // string: [optional] path to  pre-extracted Ensembl VEP cache directory
+    val_ensembl_vep_cache_tar   // string: [optional] path to  compressed Ensembl VEP cache archive
+    val_gridss_index            // string: [optional] path to  pre-built GRIDSS index directory
+    val_gridss_index_tar       // string: [optional] path to  compressed GRIDSS index archive
+    val_hmf_ensembl_data        // string: [optional] path to  pre-extracted HMF Ensembl data directory
+    val_hmf_ensembl_data_tar    // string: [optional] path to  compressed HMF Ensembl data archive
 
     main:
     def ch_genome_fasta     = channel.empty()

--- a/subworkflows/local/prepare_references/main.nf
+++ b/subworkflows/local/prepare_references/main.nf
@@ -6,34 +6,74 @@ include { UNTAR as UNTAR_HMF_ENSEMBL_DATA } from '../../../modules/nf-core/untar
 workflow PREPARE_REFERENCES {
 
     take:
-    ch_genome_fasta          // channel: [ val(meta), path(fasta) ]        genome FASTA to build the BWA-MEM2 index from
-    ch_vep_cache_tar         // channel: [ val(meta), path(archive) ]      VEP cache tar archive
-    ch_gridss_index_tar      // channel: [ val(meta), path(archive) ]      GRIDSS index tar archive
-    ch_hmf_ensembl_data_tar  // channel: [ val(meta), path(archive) ]      HMF ensembl_data tar archive
+    val_genome_fasta            // string: path to genome FASTA to build the BWA-MEM2 index from
+    val_bwamem2_index           // string: path to BWA-MEM2 index from param
+    val_ensembl_vep_cache       // string: path to Ensembl VEP cache from param
+    val_ensembl_vep_cache_tar   // string: path to VEP cache tar archive
+    val_gridss_index            // string: path to GRIDSS index from param
+    val_gridss_index_tar        // string: path to GRIDSS index tar archive
+    val_hmf_ensembl_data        // string: path to HMF ensembl_data from param
+    val_hmf_ensembl_data_tar    // string: path to HMF ensembl_data tar archive
 
     main:
+    def ch_genome_fasta     = channel.empty()
+    def ch_vep_cache        = channel.empty()
+    def ch_gridss_index     = channel.empty()
+    def ch_hmf_ensembl_data = channel.empty()
+    def ch_versions         = channel.empty()
 
-    def ch_versions = channel.empty()
+    ch_genome_fasta = channel.fromPath(val_genome_fasta).map { it -> [[id: it.simpleName], it] }.collect()
 
-    //
-    // MODULE: Build the BWA-MEM2 index on the fly from the genome FASTA
-    //
-    BWAMEM2_INDEX ( ch_genome_fasta )
-    ch_versions = ch_versions.mix(BWAMEM2_INDEX.out.versions)
+    // Genome Indexing
 
-    //
-    // MODULE: Untar directory-type references
-    //
-    UNTAR_VEP_CACHE ( ch_vep_cache_tar )
+    if (!val_bwamem2_index) {
+        BWAMEM2_INDEX ( ch_genome_fasta )
 
-    UNTAR_GRIDSS_INDEX ( ch_gridss_index_tar )
+        ch_bwamem2_index = BWAMEM2_INDEX.out.index
+        ch_versions = ch_versions.mix(BWAMEM2_INDEX.out.versions)
+    } else {
+        ch_bwamem2_index = channel.fromPath(val_bwamem2_index).map { it -> [[id: it.simpleName], it] }.collect()
+    }
 
-    UNTAR_HMF_ENSEMBL_DATA ( ch_hmf_ensembl_data_tar )
+    // Ensembl VEP Cache download and untar
+
+    if (!val_ensembl_vep_cache) {
+        ch_vep_cache_tar = channel.fromPath(val_ensembl_vep_cache_tar).map { it -> [[id: it.simpleName], it] }.collect()
+        UNTAR_VEP_CACHE ( ch_vep_cache_tar )
+
+        ch_vep_cache = UNTAR_VEP_CACHE.out.untar
+    } else {
+        ch_vep_cache = channel.fromPath(val_ensembl_vep_cache).map { it -> [[id: it.simpleName], it] }.collect()
+    }
+
+
+    // GRIDSS index download and untar
+    if (!val_gridss_index) {
+        ch_gridss_index_tar = channel.fromPath(val_gridss_index_tar).map { it -> [[id: it.simpleName], it] }.collect()
+        UNTAR_GRIDSS_INDEX ( ch_gridss_index_tar )
+
+        ch_gridss_index = UNTAR_GRIDSS_INDEX.out.untar
+    } else {
+        ch_gridss_index = channel.fromPath(val_gridss_index).map { it -> [[id: it.simpleName], it] }.collect()
+    }
+
+
+    // HMF Ensembl Data download and untar
+    if (!val_hmf_ensembl_data) {
+        ch_hmf_ensembl_data_tar = channel.fromPath(val_hmf_ensembl_data_tar).map { it -> [[id: it.simpleName], it] }.collect()
+        UNTAR_HMF_ENSEMBL_DATA ( ch_hmf_ensembl_data_tar )
+
+        ch_hmf_ensembl_data = UNTAR_HMF_ENSEMBL_DATA.out.untar
+    } else {
+        ch_hmf_ensembl_data = channel.fromPath(val_hmf_ensembl_data).map { it -> [[id: it.simpleName], it] }.collect()
+    }
+
 
     emit:
-    bwamem2_index    = BWAMEM2_INDEX.out.index             // channel: [ val(meta), path(index) ]
-    vep_cache        = UNTAR_VEP_CACHE.out.untar           // channel: [ val(meta), path(dir) ]
-    gridss_index     = UNTAR_GRIDSS_INDEX.out.untar        // channel: [ val(meta), path(dir) ]
-    hmf_ensembl_data = UNTAR_HMF_ENSEMBL_DATA.out.untar    // channel: [ val(meta), path(dir) ]
-    versions         = ch_versions                         // channel: [ path(versions.yml) ]
+    genome_fasta     = ch_genome_fasta              // channel: [ val(meta), path(fasta) ]
+    bwamem2_index    = ch_bwamem2_index             // channel: [ val(meta), path(index) ]
+    vep_cache        = ch_vep_cache                 // channel: [ val(meta), path(dir) ]
+    gridss_index     = ch_gridss_index              // channel: [ val(meta), path(dir) ]
+    hmf_ensembl_data = ch_hmf_ensembl_data          // channel: [ val(meta), path(dir) ]
+    versions         = ch_versions                  // channel: [ path(versions.yml) ]
 }

--- a/subworkflows/local/prepare_references/meta.yml
+++ b/subworkflows/local/prepare_references/meta.yml
@@ -1,0 +1,68 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+name: "prepare_references"
+description: Prepare directory-type reference genome resources by building the BWA-MEM2 index on the fly and untarring the VEP cache, GRIDSS index and HMF ensembl_data directories
+keywords:
+  - reference
+  - index
+  - bwamem2
+  - untar
+  - vep
+components:
+  - bwamem2/index
+  - untar
+input:
+  - ch_genome_fasta:
+      type: file
+      description: |
+        Genome FASTA used to build the BWA-MEM2 index on the fly
+        Structure: [ val(meta), path(fasta) ]
+      pattern: "*.{fa,fasta}"
+  - ch_vep_cache_tar:
+      type: file
+      description: |
+        VEP cache directory packaged as a tar archive
+        Structure: [ val(meta), path(archive) ]
+      pattern: "*.{tar,tar.gz}"
+  - ch_gridss_index_tar:
+      type: file
+      description: |
+        GRIDSS index directory packaged as a tar archive
+        Structure: [ val(meta), path(archive) ]
+      pattern: "*.{tar,tar.gz}"
+  - ch_hmf_ensembl_data_tar:
+      type: file
+      description: |
+        HMF ensembl_data directory packaged as a tar archive
+        Structure: [ val(meta), path(archive) ]
+      pattern: "*.{tar,tar.gz}"
+output:
+  - bwamem2_index:
+      type: directory
+      description: |
+        BWA-MEM2 index built from the genome FASTA
+        Structure: [ val(meta), path(index) ]
+  - vep_cache:
+      type: directory
+      description: |
+        Untarred VEP cache directory
+        Structure: [ val(meta), path(dir) ]
+  - gridss_index:
+      type: directory
+      description: |
+        Untarred GRIDSS index directory
+        Structure: [ val(meta), path(dir) ]
+  - hmf_ensembl_data:
+      type: directory
+      description: |
+        Untarred HMF ensembl_data directory
+        Structure: [ val(meta), path(dir) ]
+  - versions:
+      type: file
+      description: |
+        File containing software versions
+        Structure: [ path(versions.yml) ]
+      pattern: "versions.yml"
+authors:
+  - "@imsarath"
+maintainers:
+  - "@imsarath"

--- a/subworkflows/local/prepare_references/meta.yml
+++ b/subworkflows/local/prepare_references/meta.yml
@@ -11,31 +11,53 @@ components:
   - bwamem2/index
   - untar
 input:
-  - ch_genome_fasta:
-      type: file
+  - val_genome_fasta:
+      type: string
       description: |
-        Genome FASTA used to build the BWA-MEM2 index on the fly
-        Structure: [ val(meta), path(fasta) ]
+        Path to the genome FASTA used to build the BWA-MEM2 index on the fly
       pattern: "*.{fa,fasta}"
-  - ch_vep_cache_tar:
-      type: file
+  - val_bwamem2_index:
+      type: string
       description: |
-        VEP cache directory packaged as a tar archive
-        Structure: [ val(meta), path(archive) ]
+        Path to a pre-built BWA-MEM2 index directory. When set, the index is
+        used as-is instead of being built from the genome FASTA.
+  - val_ensembl_vep_cache:
+      type: string
+      description: |
+        Path to a pre-extracted Ensembl VEP cache directory. When set, the
+        VEP cache archive is not untarred.
+  - val_ensembl_vep_cache_tar:
+      type: string
+      description: |
+        Path to the VEP cache directory packaged as a tar archive
       pattern: "*.{tar,tar.gz}"
-  - ch_gridss_index_tar:
-      type: file
+  - val_gridss_index:
+      type: string
       description: |
-        GRIDSS index directory packaged as a tar archive
-        Structure: [ val(meta), path(archive) ]
+        Path to a pre-extracted GRIDSS index directory. When set, the GRIDSS
+        index archive is not untarred.
+  - val_gridss_index_tar:
+      type: string
+      description: |
+        Path to the GRIDSS index directory packaged as a tar archive
       pattern: "*.{tar,tar.gz}"
-  - ch_hmf_ensembl_data_tar:
-      type: file
+  - val_hmf_ensembl_data:
+      type: string
       description: |
-        HMF ensembl_data directory packaged as a tar archive
-        Structure: [ val(meta), path(archive) ]
+        Path to a pre-extracted HMF ensembl_data directory. When set, the
+        HMF ensembl_data archive is not untarred.
+  - val_hmf_ensembl_data_tar:
+      type: string
+      description: |
+        Path to the HMF ensembl_data directory packaged as a tar archive
       pattern: "*.{tar,tar.gz}"
 output:
+  - genome_fasta:
+      type: file
+      description: |
+        Genome FASTA staged with a meta map
+        Structure: [ val(meta), path(fasta) ]
+      pattern: "*.{fa,fasta}"
   - bwamem2_index:
       type: directory
       description: |

--- a/subworkflows/local/prepare_references/tests/main.nf.test
+++ b/subworkflows/local/prepare_references/tests/main.nf.test
@@ -1,0 +1,95 @@
+nextflow_workflow {
+
+    name "Test Subworkflow PREPARE_REFERENCES"
+    script "../main.nf"
+    workflow "PREPARE_REFERENCES"
+
+    tag "subworkflows"
+    tag "subworkflows_local"
+    tag "prepare_references"
+    tag "bwamem2"
+    tag "bwamem2/index"
+    tag "untar"
+
+    test("build bwamem2 index and untar directories") {
+
+        when {
+            workflow {
+                """
+                input[0] = channel.of([
+                    [ id:'genome_fasta' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.fasta', checkIfExists: true)
+                ])
+                input[1] = channel.of([
+                    [ id:'vep_cache' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/vep.tar.gz', checkIfExists: true)
+                ])
+                input[2] = channel.of([
+                    [ id:'gridss_index' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/gridss_index.tar.gz', checkIfExists: true)
+                ])
+                input[3] = channel.of([
+                    [ id:'ensembl_data' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/ensembl_data.tar.gz', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    // BWA-MEM2 index binaries are not guaranteed reproducible across versions,
+                    // so snapshot only the sorted file listing of the index directory.
+                    workflow.out.bwamem2_index.collect { meta, dir -> [meta, file(dir).list().sort()] },
+                    workflow.out.vep_cache,
+                    workflow.out.gridss_index,
+                    workflow.out.hmf_ensembl_data,
+                    workflow.out.versions
+                ).match() }
+            )
+        }
+    }
+
+    test("build bwamem2 index and untar directories - stub") {
+
+        options "-stub"
+
+        when {
+            workflow {
+                """
+                input[0] = channel.of([
+                    [ id:'genome_fasta' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.fasta', checkIfExists: true)
+                ])
+                input[1] = channel.of([
+                    [ id:'vep_cache' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/vep.tar.gz', checkIfExists: true)
+                ])
+                input[2] = channel.of([
+                    [ id:'gridss_index' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/gridss_index.tar.gz', checkIfExists: true)
+                ])
+                input[3] = channel.of([
+                    [ id:'ensembl_data' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/ensembl_data.tar.gz', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    workflow.out.bwamem2_index.collect { meta, dir -> [meta, file(dir).list().sort()] },
+                    workflow.out.vep_cache,
+                    workflow.out.gridss_index,
+                    workflow.out.hmf_ensembl_data,
+                    workflow.out.versions
+                ).match() }
+            )
+        }
+    }
+}

--- a/subworkflows/local/prepare_references/tests/main.nf.test
+++ b/subworkflows/local/prepare_references/tests/main.nf.test
@@ -16,22 +16,16 @@ nextflow_workflow {
         when {
             workflow {
                 """
-                input[0] = channel.of([
-                    [ id:'genome_fasta' ],
-                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.fasta', checkIfExists: true)
-                ])
-                input[1] = channel.of([
-                    [ id:'vep_cache' ],
-                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/vep.tar.gz', checkIfExists: true)
-                ])
-                input[2] = channel.of([
-                    [ id:'gridss_index' ],
-                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/gridss_index.tar.gz', checkIfExists: true)
-                ])
-                input[3] = channel.of([
-                    [ id:'ensembl_data' ],
-                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/ensembl_data.tar.gz', checkIfExists: true)
-                ])
+                // No pre-built index/cache/data paths provided, so the subworkflow
+                // builds the BWA-MEM2 index and untars the VEP, GRIDSS and HMF archives.
+                input[0] = params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.fasta'
+                input[1] = null
+                input[2] = null
+                input[3] = params.pipelines_testdata_base_path + 'reference/GRCh37/vep.tar.gz'
+                input[4] = null
+                input[5] = params.pipelines_testdata_base_path + 'reference/GRCh37/gridss_index.tar.gz'
+                input[6] = null
+                input[7] = params.pipelines_testdata_base_path + 'reference/GRCh37/ensembl_data.tar.gz'
                 """
             }
         }
@@ -40,6 +34,7 @@ nextflow_workflow {
             assertAll(
                 { assert workflow.success },
                 { assert snapshot(
+                    workflow.out.genome_fasta,
                     // BWA-MEM2 index binaries are not guaranteed reproducible across versions,
                     // so snapshot only the sorted file listing of the index directory.
                     workflow.out.bwamem2_index.collect { meta, dir -> [meta, file(dir).list().sort()] },
@@ -59,22 +54,14 @@ nextflow_workflow {
         when {
             workflow {
                 """
-                input[0] = channel.of([
-                    [ id:'genome_fasta' ],
-                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.fasta', checkIfExists: true)
-                ])
-                input[1] = channel.of([
-                    [ id:'vep_cache' ],
-                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/vep.tar.gz', checkIfExists: true)
-                ])
-                input[2] = channel.of([
-                    [ id:'gridss_index' ],
-                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/gridss_index.tar.gz', checkIfExists: true)
-                ])
-                input[3] = channel.of([
-                    [ id:'ensembl_data' ],
-                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/ensembl_data.tar.gz', checkIfExists: true)
-                ])
+                input[0] = params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.fasta'
+                input[1] = null
+                input[2] = null
+                input[3] = params.pipelines_testdata_base_path + 'reference/GRCh37/vep.tar.gz'
+                input[4] = null
+                input[5] = params.pipelines_testdata_base_path + 'reference/GRCh37/gridss_index.tar.gz'
+                input[6] = null
+                input[7] = params.pipelines_testdata_base_path + 'reference/GRCh37/ensembl_data.tar.gz'
                 """
             }
         }
@@ -83,6 +70,7 @@ nextflow_workflow {
             assertAll(
                 { assert workflow.success },
                 { assert snapshot(
+                    workflow.out.genome_fasta,
                     workflow.out.bwamem2_index.collect { meta, dir -> [meta, file(dir).list().sort()] },
                     workflow.out.vep_cache,
                     workflow.out.gridss_index,

--- a/subworkflows/local/prepare_references/tests/main.nf.test
+++ b/subworkflows/local/prepare_references/tests/main.nf.test
@@ -35,9 +35,7 @@ nextflow_workflow {
                 { assert workflow.success },
                 { assert snapshot(
                     workflow.out.genome_fasta,
-                    // BWA-MEM2 index binaries are not guaranteed reproducible across versions,
-                    // so snapshot only the sorted file listing of the index directory.
-                    workflow.out.bwamem2_index.collect { meta, dir -> [meta, file(dir).list().sort()] },
+                    workflow.out.bwamem2_index,
                     workflow.out.vep_cache,
                     workflow.out.gridss_index,
                     workflow.out.hmf_ensembl_data,
@@ -71,7 +69,7 @@ nextflow_workflow {
                 { assert workflow.success },
                 { assert snapshot(
                     workflow.out.genome_fasta,
-                    workflow.out.bwamem2_index.collect { meta, dir -> [meta, file(dir).list().sort()] },
+                    workflow.out.bwamem2_index,
                     workflow.out.vep_cache,
                     workflow.out.gridss_index,
                     workflow.out.hmf_ensembl_data,

--- a/subworkflows/local/prepare_references/tests/main.nf.test.snap
+++ b/subworkflows/local/prepare_references/tests/main.nf.test.snap
@@ -15,11 +15,11 @@
                         "id": "human_g1k_v37_decoy"
                     },
                     [
-                        "human_g1k_v37_decoy.fasta.0123",
-                        "human_g1k_v37_decoy.fasta.amb",
-                        "human_g1k_v37_decoy.fasta.ann",
-                        "human_g1k_v37_decoy.fasta.bwt.2bit.64",
-                        "human_g1k_v37_decoy.fasta.pac"
+                        "human_g1k_v37_decoy.fasta.0123:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "human_g1k_v37_decoy.fasta.amb:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "human_g1k_v37_decoy.fasta.ann:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "human_g1k_v37_decoy.fasta.bwt.2bit.64:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "human_g1k_v37_decoy.fasta.pac:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ]
             ],
@@ -73,7 +73,7 @@
                 "versions.yml:md5,db07d261e269c4220700d88fc906a833"
             ]
         ],
-        "timestamp": "2026-07-13T14:19:24.399813217",
+        "timestamp": "2026-07-14T13:34:41.895600666",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "26.04.3"
@@ -95,11 +95,11 @@
                         "id": "human_g1k_v37_decoy"
                     },
                     [
-                        "human_g1k_v37_decoy.fasta.0123",
-                        "human_g1k_v37_decoy.fasta.amb",
-                        "human_g1k_v37_decoy.fasta.ann",
-                        "human_g1k_v37_decoy.fasta.bwt.2bit.64",
-                        "human_g1k_v37_decoy.fasta.pac"
+                        "human_g1k_v37_decoy.fasta.0123:md5,6472290de5b900994d6c15aacb9954c0",
+                        "human_g1k_v37_decoy.fasta.amb:md5,3a91cbbc3499c6a863a05a7fc0e32706",
+                        "human_g1k_v37_decoy.fasta.ann:md5,fce467dcdf286be017241e1410a54af1",
+                        "human_g1k_v37_decoy.fasta.bwt.2bit.64:md5,0490fdd14a2a4c9c5f22130c8f58d2a6",
+                        "human_g1k_v37_decoy.fasta.pac:md5,2f66557292b6f30d6a17d115fad85acb"
                     ]
                 ]
             ],
@@ -153,7 +153,7 @@
                 "versions.yml:md5,db07d261e269c4220700d88fc906a833"
             ]
         ],
-        "timestamp": "2026-07-13T14:19:14.522123735",
+        "timestamp": "2026-07-14T13:33:08.05634036",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "26.04.3"

--- a/subworkflows/local/prepare_references/tests/main.nf.test.snap
+++ b/subworkflows/local/prepare_references/tests/main.nf.test.snap
@@ -1,0 +1,142 @@
+{
+    "build bwamem2 index and untar directories - stub": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "genome_fasta"
+                    },
+                    [
+                        "human_g1k_v37_decoy.fasta.0123",
+                        "human_g1k_v37_decoy.fasta.amb",
+                        "human_g1k_v37_decoy.fasta.ann",
+                        "human_g1k_v37_decoy.fasta.bwt.2bit.64",
+                        "human_g1k_v37_decoy.fasta.pac"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "vep_cache"
+                    },
+                    [
+                        
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "gridss_index"
+                    },
+                    [
+                        "human_g1k_v37_decoy.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "human_g1k_v37_decoy.fasta.amb:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "human_g1k_v37_decoy.fasta.ann:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "human_g1k_v37_decoy.fasta.bwt:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "human_g1k_v37_decoy.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "human_g1k_v37_decoy.fasta.gridsscache:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "human_g1k_v37_decoy.fasta.img:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "human_g1k_v37_decoy.fasta.pac:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "human_g1k_v37_decoy.fasta.sa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "ensembl_data"
+                    },
+                    [
+                        "ensembl_gene_data.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "ensembl_protein_features.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "ensembl_trans_amino_acids.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "ensembl_trans_exon_data.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "ensembl_trans_splice_data.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ]
+            ],
+            [
+                "versions.yml:md5,db07d261e269c4220700d88fc906a833"
+            ]
+        ],
+        "timestamp": "2026-07-07T15:54:42.399903876",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "26.04.3"
+        }
+    },
+    "build bwamem2 index and untar directories": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "genome_fasta"
+                    },
+                    [
+                        "human_g1k_v37_decoy.fasta.0123",
+                        "human_g1k_v37_decoy.fasta.amb",
+                        "human_g1k_v37_decoy.fasta.ann",
+                        "human_g1k_v37_decoy.fasta.bwt.2bit.64",
+                        "human_g1k_v37_decoy.fasta.pac"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "vep_cache"
+                    },
+                    [
+                        [
+                            [
+                                "info.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "gridss_index"
+                    },
+                    [
+                        "human_g1k_v37_decoy.fasta:md5,ca2d0bc7c83afd32621e3dfed73943de",
+                        "human_g1k_v37_decoy.fasta.amb:md5,3a91cbbc3499c6a863a05a7fc0e32706",
+                        "human_g1k_v37_decoy.fasta.ann:md5,fce467dcdf286be017241e1410a54af1",
+                        "human_g1k_v37_decoy.fasta.bwt:md5,a89e9dd9ecd2071f7927047c31d07df3",
+                        "human_g1k_v37_decoy.fasta.fai:md5,b185081fee633132bd2f6f12d715179b",
+                        "human_g1k_v37_decoy.fasta.gridsscache:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "human_g1k_v37_decoy.fasta.img:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "human_g1k_v37_decoy.fasta.pac:md5,2f66557292b6f30d6a17d115fad85acb",
+                        "human_g1k_v37_decoy.fasta.sa:md5,61f23d7daf4e80946cdc61581dc9c1c1"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "ensembl_data"
+                    },
+                    [
+                        "ensembl_gene_data.csv:md5,b4847bcf74efdef14b413852ba354584",
+                        "ensembl_protein_features.csv:md5,c6b9143310ff5d66b99866fe49b1046b",
+                        "ensembl_trans_amino_acids.csv:md5,d8bf851c14436f4b6f166fec41596726",
+                        "ensembl_trans_exon_data.csv:md5,8992e3039c32d7dfcbb1d831f66c7b7f",
+                        "ensembl_trans_splice_data.csv:md5,7c93a4b2b30c9d3b5cf907b31e8bda93"
+                    ]
+                ]
+            ],
+            [
+                "versions.yml:md5,db07d261e269c4220700d88fc906a833"
+            ]
+        ],
+        "timestamp": "2026-07-07T15:54:13.425585788",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "26.04.3"
+        }
+    }
+}

--- a/subworkflows/local/prepare_references/tests/main.nf.test.snap
+++ b/subworkflows/local/prepare_references/tests/main.nf.test.snap
@@ -4,7 +4,15 @@
             [
                 [
                     {
-                        "id": "genome_fasta"
+                        "id": "human_g1k_v37_decoy"
+                    },
+                    "/imsarath/test-data/refs/heads/main/reference/GRCh37/genome/human_g1k_v37_decoy.fasta"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "human_g1k_v37_decoy"
                     },
                     [
                         "human_g1k_v37_decoy.fasta.0123",
@@ -18,10 +26,14 @@
             [
                 [
                     {
-                        "id": "vep_cache"
+                        "id": "vep"
                     },
                     [
-                        
+                        [
+                            [
+                                "info.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                            ]
+                        ]
                     ]
                 ]
             ],
@@ -61,7 +73,7 @@
                 "versions.yml:md5,db07d261e269c4220700d88fc906a833"
             ]
         ],
-        "timestamp": "2026-07-07T15:54:42.399903876",
+        "timestamp": "2026-07-13T14:19:24.399813217",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "26.04.3"
@@ -72,7 +84,15 @@
             [
                 [
                     {
-                        "id": "genome_fasta"
+                        "id": "human_g1k_v37_decoy"
+                    },
+                    "/imsarath/test-data/refs/heads/main/reference/GRCh37/genome/human_g1k_v37_decoy.fasta"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "human_g1k_v37_decoy"
                     },
                     [
                         "human_g1k_v37_decoy.fasta.0123",
@@ -86,7 +106,7 @@
             [
                 [
                     {
-                        "id": "vep_cache"
+                        "id": "vep"
                     },
                     [
                         [
@@ -133,7 +153,7 @@
                 "versions.yml:md5,db07d261e269c4220700d88fc906a833"
             ]
         ],
-        "timestamp": "2026-07-07T15:54:13.425585788",
+        "timestamp": "2026-07-13T14:19:14.522123735",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "26.04.3"


### PR DESCRIPTION
This PR adds a minimal `PREPARE_REFERENCES` subworkflow. This lays the groundwork for fixing the test profile in an upcoming PR so it can run on a small, real dataset (#46).

### Added

   - `PREPARE_REFERENCES` subworkflow: builds the BWA-MEM2 index and untars the VEP cache, GRIDSS index, and HMF `ensembl_data` references, falling back to pre-built paths when provided.
  - Integrated `PREPARE_REFERENCES` into the main workflow to source the reference channels.
  - New parameters `ensembl_vep_cache_tar`, `gridss_index_tar`, and `hmf_ensembl_data_tar` for the tar archives.
  - nf-core `untar` module.
  - nf-test for the subworkflow (with and without `-stub`).