### PR TITLE
fix: add tumor-segmentation arg to GATK4_CALCULATECONTAMINATION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Initial release of genomic-medicine-sweden/autoseq, created with the [nf-core](h
 - [ #21 ](https://github.com/genomic-medicine-sweden/nf-autoseq/pull/21) Added the modified nf_core_autoseq logo images to .nf-core.yml to ignore them and resolve nf-core linting failures.
 - [ #37 ](https://github.com/genomic-medicine-sweden/autoseq/pull/38) Updated documentation reference in `multiqc_config.yml` and disabled the nf-core linting check for multiqc config.
 - [ #41 ](https://github.com/genomic-medicine-sweden/autoseq/pull/41) Refactored `annotate_cnvs` local module to accept `sample_type` as part of the input tuple instead of deriving it from `meta.sample_type` inside the module.
-- [ #XX ](https://github.com/genomic-medicine-sweden/autoseq/pull/XX) Added `-tumor-segmentation` argument to `GATK4_CALCULATECONTAMINATION` so the tumor segmentation table is written for downstream filtering.
+- [ #53 ](https://github.com/genomic-medicine-sweden/autoseq/pull/53) Added `-tumor-segmentation` argument to `GATK4_CALCULATECONTAMINATION` so the tumor segmentation table is written for downstream filtering.
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Initial release of genomic-medicine-sweden/autoseq, created with the [nf-core](h
 - [ #21 ](https://github.com/genomic-medicine-sweden/nf-autoseq/pull/21) Added the modified nf_core_autoseq logo images to .nf-core.yml to ignore them and resolve nf-core linting failures.
 - [ #37 ](https://github.com/genomic-medicine-sweden/autoseq/pull/38) Updated documentation reference in `multiqc_config.yml` and disabled the nf-core linting check for multiqc config.
 - [ #41 ](https://github.com/genomic-medicine-sweden/autoseq/pull/41) Refactored `annotate_cnvs` local module to accept `sample_type` as part of the input tuple instead of deriving it from `meta.sample_type` inside the module.
+- [ #XX ](https://github.com/genomic-medicine-sweden/autoseq/pull/XX) Added `-tumor-segmentation` argument to `GATK4_CALCULATECONTAMINATION` so the tumor segmentation table is written for downstream filtering.
 
 ### `Dependencies`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -88,6 +88,7 @@ process {
     }
 
     withName: '.*:CALL_GATK_MUTECT2:GATK4_CALCULATECONTAMINATION' {
+        ext.args   = { " -tumor-segmentation ${meta.id}.segmentation.table " }
         ext.prefix = { "${meta.tumor_id}_${meta.normal_id}" }
     }
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -88,7 +88,7 @@ process {
     }
 
     withName: '.*:CALL_GATK_MUTECT2:GATK4_CALCULATECONTAMINATION' {
-        ext.args   = { " -tumor-segmentation ${meta.id}.segmentation.table " }
+        ext.args   = { " --tumor-segmentation ${meta.id}.segmentation.table " }
         ext.prefix = { "${meta.tumor_id}_${meta.normal_id}" }
     }
 


### PR DESCRIPTION
This change was split out from the `fix_test_profile` work into a standalone PR. It's one of a few small, independent fixes required to get the `-profile test` run passing end-to-end. Keeping them as separate PRs keeps each change scoped and easy to review.

### Fixed

- Added `-tumor-segmentation` argument to `GATK4_CALCULATECONTAMINATION` so the tumor segmentation table is emitted for downstream Mutect2 filtering.