### PR TITLE
fix: index mutect2 pass-filtered VCF for SOMATIC_VCFMERGE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ Initial release of genomic-medicine-sweden/autoseq, created with the [nf-core](h
 - [ #37 ](https://github.com/genomic-medicine-sweden/autoseq/pull/38) Updated documentation reference in `multiqc_config.yml` and disabled the nf-core linting check for multiqc config.
 - [ #41 ](https://github.com/genomic-medicine-sweden/autoseq/pull/41) Refactored `annotate_cnvs` local module to accept `sample_type` as part of the input tuple instead of deriving it from `meta.sample_type` inside the module.
 - [ #52 ](https://github.com/genomic-medicine-sweden/autoseq/pull/52) Replaced leftover `oncorefiner` references in `docs/CONTRIBUTING.md` with the correct pipeline name `autoseq`.
-- [ #XX ](https://github.com/genomic-medicine-sweden/autoseq/pull/XX) Emit a tabix index for the Mutect2 pass-filtered VCF and pass it to `SOMATIC_VCFMERGE` so `bcftools concat -a` can load the index.
+- [ #54 ](https://github.com/genomic-medicine-sweden/autoseq/pull/54) Emit a tabix index for the Mutect2 pass-filtered VCF and pass it to `SOMATIC_VCFMERGE` so `bcftools concat -a` can load the index.
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Initial release of genomic-medicine-sweden/autoseq, created with the [nf-core](h
 - [ #21 ](https://github.com/genomic-medicine-sweden/nf-autoseq/pull/21) Added the modified nf_core_autoseq logo images to .nf-core.yml to ignore them and resolve nf-core linting failures.
 - [ #37 ](https://github.com/genomic-medicine-sweden/autoseq/pull/38) Updated documentation reference in `multiqc_config.yml` and disabled the nf-core linting check for multiqc config.
 - [ #41 ](https://github.com/genomic-medicine-sweden/autoseq/pull/41) Refactored `annotate_cnvs` local module to accept `sample_type` as part of the input tuple instead of deriving it from `meta.sample_type` inside the module.
+- [ #XX ](https://github.com/genomic-medicine-sweden/autoseq/pull/XX) Emit a tabix index for the Mutect2 pass-filtered VCF and pass it to `SOMATIC_VCFMERGE` so `bcftools concat -a` can load the index.
 
 ### `Dependencies`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -104,6 +104,9 @@ process {
     }
 
     withName: '.*:CALL_SOMATIC_SNVS:PASSFILTER_FOR_MUTECT2' {
+        // Emit bgzipped + tabix-indexed VCF so SOMATIC_VCFMERGE's `bcftools concat -a`
+        // (allow-overlaps) can load the index; -a requires indexed inputs.
+        ext.args   = '--output-type z --write-index=tbi'
         ext.prefix = { "${meta.tumor_id}_${meta.normal_id}_mutect2_pass_only" }
     }
 

--- a/modules/local/vcfmerge/main.nf
+++ b/modules/local/vcfmerge/main.nf
@@ -9,7 +9,7 @@ process SOMATIC_VCFMERGE {
         'community.wave.seqera.io/library/bcftools_tabix:04336756d7b46b1b' }"
 
     input:
-    tuple val(meta), path(mutect_vcf)
+    tuple val(meta), path(mutect_vcf), path(mutect_tbi)
     tuple val(meta2), path(sage_vcf)
 
     output:

--- a/subworkflows/local/call_somatic_snvs/main.nf
+++ b/subworkflows/local/call_somatic_snvs/main.nf
@@ -90,7 +90,7 @@ workflow CALL_SOMATIC_SNVS {
     PASSFILTER_FOR_SAGE (ch_sage_vcf)
 
     SOMATIC_VCFMERGE (
-        PASSFILTER_FOR_MUTECT2.out.vcf,
+        PASSFILTER_FOR_MUTECT2.out.vcf.join(PASSFILTER_FOR_MUTECT2.out.tbi),
         PASSFILTER_FOR_SAGE.out.vcf
     )
 


### PR DESCRIPTION
This change was split out from the `fix_test_profile` work into a standalone PR. It's one of a few small, independent fixes required to get the `-profile test` run passing end-to-end. Keeping them as separate PRs keeps each change scoped and easy to review.

### Fixed

- Emit a tabix index for the Mutect2 pass-filtered VCF and pass it to `SOMATIC_VCFMERGE` so `bcftools concat -a` can load the index.