### PR TITLE
fix: use meta.id for PureCN output prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Initial release of genomic-medicine-sweden/autoseq, created with the [nf-core](h
 - [ #21 ](https://github.com/genomic-medicine-sweden/nf-autoseq/pull/21) Added the modified nf_core_autoseq logo images to .nf-core.yml to ignore them and resolve nf-core linting failures.
 - [ #37 ](https://github.com/genomic-medicine-sweden/autoseq/pull/38) Updated documentation reference in `multiqc_config.yml` and disabled the nf-core linting check for multiqc config.
 - [ #41 ](https://github.com/genomic-medicine-sweden/autoseq/pull/41) Refactored `annotate_cnvs` local module to accept `sample_type` as part of the input tuple instead of deriving it from `meta.sample_type` inside the module.
+- [ #XX ](https://github.com/genomic-medicine-sweden/autoseq/pull/XX) Use `meta.id` instead of `meta.tumor_id` for the `PURECN_RUN` output prefix.
 
 ### `Dependencies`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -161,6 +161,6 @@ process {
             "--post-optimize"
             ].join(' ')
         }
-        ext.prefix = { "${meta.tumor_id}_purecn" }
+        ext.prefix = { "${meta.id}_purecn" }
     }
 }


### PR DESCRIPTION
This change was split out from the `fix_test_profile` work into a standalone PR - #55

### Fixed

- Use `meta.id` instead of `meta.tumor_id` for the `PURECN_RUN` output prefix.