### PR TITLE
test: real-VCF nf-tests for PureCN and tumor biomarker profiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Initial release of genomic-medicine-sweden/autoseq, created with the [nf-core](h
 - [ #53 ](https://github.com/genomic-medicine-sweden/autoseq/pull/53) Added `-tumor-segmentation` argument to `GATK4_CALCULATECONTAMINATION` so the tumor segmentation table is written for downstream filtering.
 - [ #54 ](https://github.com/genomic-medicine-sweden/autoseq/pull/54) Emit a tabix index for the Mutect2 pass-filtered VCF and pass it to `SOMATIC_VCFMERGE` so `bcftools concat -a` can load the index.
 - [ #56 ](https://github.com/genomic-medicine-sweden/autoseq/pull/56) Use `meta.id` instead of `meta.tumor_id` for the `PURECN_RUN` output prefix.
+- [ #58 ](https://github.com/genomic-medicine-sweden/autoseq/pull/58) Replaced the stubbed `PURECN_RUN` and `PROFILE_TUMOR_BIOMARKERS` nf-tests with real-VCF runs, added dedicated stub cases, and regenerated the snapshots.
 
 ### `Dependencies`
 

--- a/modules/local/purecn/run/tests/main.nf.test
+++ b/modules/local/purecn/run/tests/main.nf.test
@@ -10,17 +10,11 @@ nextflow_process {
 
     test("purecn_run with presegmentation - with VCF") {
 
-        options "-stub "
-
-        // TODO: PureCN requires specific germline/somatic tags that are difficult to mock manually.
-        // I've implemented the stub as a temporary measure so we can move forward;
-        // we'll transition to a real VCF once the end-to-end test data is available.
-
         when {
             process {
                 """
                 input[0] = Channel.of([
-                    [ id:'test_sample', tumor_id: 'test_tumor'],
+                    [ id:'test_sample'],
                     file(params.pipelines_testdata_base_path + 'testdata/purecn/test.paired_end.sorted.cnr', checkIfExists: true),
                     file(params.pipelines_testdata_base_path + 'testdata/purecn/test.paired_end.sorted.seg', checkIfExists: true),
                     file(params.pipelines_testdata_base_path + 'testdata/purecn/test.mutect2_calls.vcf.gz', checkIfExists: true)
@@ -33,7 +27,17 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                // NOTE: PDFs are non-deterministic (R embeds timestamps), so assert existence only
+                // The remaining outputs (like _loh.csv, _genes.csv and _variants.csv) are conditional;
+                // PureCN only generates them if the input data contains specific biological events.
+                { assert process.out.pdf[0][1].every { f -> path(f).exists() } },
+                { assert snapshot(
+                    path(process.out.local_optima_pdf[0][1]).exists(),
+                    path(process.out.segmentation_pdf[0][1]).exists(),
+                    process.out.csv,
+                    process.out.seg,
+                    process.out.versions_purecn
+                ).match() }
             )
         }
     }
@@ -44,7 +48,7 @@ nextflow_process {
             process {
                 """
                 input[0] = Channel.of([
-                    [ id:'test_sample', tumor_id: 'test_tumor'],
+                    [ id:'test_sample'],
                     file(params.pipelines_testdata_base_path + 'testdata/purecn/test.paired_end.sorted.cnr', checkIfExists: true),
                     file(params.pipelines_testdata_base_path + 'testdata/purecn/test.paired_end.sorted.seg', checkIfExists: true),
                     []
@@ -57,19 +61,40 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                // NOTE: PDFs are non-deterministic (R embeds timestamps), so assert existence only
-                { assert process.out.pdf[0][1].every { f -> file(f).exists() } },
-                { assert file(process.out.local_optima_pdf[0][1]).exists() },
-                { assert file(process.out.segmentation_pdf[0][1]).exists() },
-                // NOTE:
-                // The remaining outputs (like _loh.csv and _variants.csv) are conditional;
-                // PureCN only generates them if the input data contains specific biological events.
                 { assert snapshot(
+                    path(process.out.local_optima_pdf[0][1]).exists(),
+                    path(process.out.segmentation_pdf[0][1]).exists(),
                     process.out.csv,
                     process.out.seg,
                     process.out.genes_csv,
                     process.out.versions_purecn
                 ).match() }
+            )
+        }
+    }
+
+    test("purecn_run with presegmentation - stub") {
+
+        options " -stub "
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test_sample'],
+                    file(params.pipelines_testdata_base_path + 'testdata/purecn/test.paired_end.sorted.cnr', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'testdata/purecn/test.paired_end.sorted.seg', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'testdata/purecn/test.mutect2_calls.vcf.gz', checkIfExists: true)
+                ])
+                input[1] = 'hg19'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/local/purecn/run/tests/main.nf.test.snap
+++ b/modules/local/purecn/run/tests/main.nf.test.snap
@@ -1,80 +1,83 @@
 {
     "purecn_run with presegmentation - with VCF": {
         "content": [
+            true,
+            true,
+            [
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "test_sample_purecn.csv:md5,6509c326c007900ef35aed58bfc34d55"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "test_sample_purecn_dnacopy.seg:md5,66f07319606b91dbff767dba416e9cf1"
+                ]
+            ],
+            [
+                [
+                    "PURECN_RUN",
+                    "PureCN",
+                    "2.12.0"
+                ]
+            ]
+        ],
+        "timestamp": "2026-07-21T17:46:09.868807972",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "26.04.3"
+        }
+    },
+    "purecn_run with presegmentation - without VCF": {
+        "content": [
+            true,
+            true,
+            [
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "test_sample_purecn.csv:md5,6509c326c007900ef35aed58bfc34d55"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "test_sample_purecn_dnacopy.seg:md5,66f07319606b91dbff767dba416e9cf1"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "test_sample_purecn_genes.csv:md5,a1485ae8fc2e3aa20acb01b9489fbc18"
+                ]
+            ],
+            [
+                [
+                    "PURECN_RUN",
+                    "PureCN",
+                    "2.12.0"
+                ]
+            ]
+        ],
+        "timestamp": "2026-07-21T17:46:29.615454253",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "26.04.3"
+        }
+    },
+    "purecn_run with presegmentation - stub": {
+        "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test_sample",
-                            "tumor_id": "test_tumor"
-                        },
-                        [
-                            "test_tumor_purecn.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "test_tumor_purecn_local_optima.pdf:md5,d41d8cd98f00b204e9800998ecf8427e"
-                        ]
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test_sample",
-                            "tumor_id": "test_tumor"
-                        },
-                        "test_tumor_purecn_local_optima.pdf:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "10": [
-                    
-                ],
-                "11": [
-                    
-                ],
-                "12": [
-                    
-                ],
-                "13": [
-                    [
-                        "PURECN_RUN",
-                        "PureCN",
-                        "2.12.0"
-                    ]
-                ],
-                "2": [
-                    [
-                        {
-                            "id": "test_sample",
-                            "tumor_id": "test_tumor"
-                        },
-                        "test_tumor_purecn.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "3": [
-                    [
-                        {
-                            "id": "test_sample",
-                            "tumor_id": "test_tumor"
-                        },
-                        "test_tumor_purecn_dnacopy.seg:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "4": [
-                    
-                ],
-                "5": [
-                    
-                ],
-                "6": [
-                    
-                ],
-                "7": [
-                    
-                ],
-                "8": [
-                    
-                ],
-                "9": [
-                    
-                ],
                 "amplification_pvalues_csv": [
                     
                 ],
@@ -84,10 +87,9 @@
                 "csv": [
                     [
                         {
-                            "id": "test_sample",
-                            "tumor_id": "test_tumor"
+                            "id": "test_sample"
                         },
-                        "test_tumor_purecn.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test_sample_purecn.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "genes_csv": [
@@ -96,10 +98,9 @@
                 "local_optima_pdf": [
                     [
                         {
-                            "id": "test_sample",
-                            "tumor_id": "test_tumor"
+                            "id": "test_sample"
                         },
-                        "test_tumor_purecn_local_optima.pdf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test_sample_purecn_local_optima.pdf:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "log": [
@@ -114,22 +115,20 @@
                 "pdf": [
                     [
                         {
-                            "id": "test_sample",
-                            "tumor_id": "test_tumor"
+                            "id": "test_sample"
                         },
                         [
-                            "test_tumor_purecn.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "test_tumor_purecn_local_optima.pdf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                            "test_sample_purecn.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "test_sample_purecn_local_optima.pdf:md5,d41d8cd98f00b204e9800998ecf8427e"
                         ]
                     ]
                 ],
                 "seg": [
                     [
                         {
-                            "id": "test_sample",
-                            "tumor_id": "test_tumor"
+                            "id": "test_sample"
                         },
-                        "test_tumor_purecn_dnacopy.seg:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test_sample_purecn_dnacopy.seg:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "segmentation_pdf": [
@@ -150,53 +149,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-04-23T14:03:24.883170796",
+        "timestamp": "2026-07-21T17:46:40.898858868",
         "meta": {
             "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
-        }
-    },
-    "purecn_run with presegmentation - without VCF": {
-        "content": [
-            [
-                [
-                    {
-                        "id": "test_sample",
-                        "tumor_id": "test_tumor"
-                    },
-                    "test_tumor_purecn.csv:md5,6509c326c007900ef35aed58bfc34d55"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test_sample",
-                        "tumor_id": "test_tumor"
-                    },
-                    "test_tumor_purecn_dnacopy.seg:md5,66f07319606b91dbff767dba416e9cf1"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test_sample",
-                        "tumor_id": "test_tumor"
-                    },
-                    "test_tumor_purecn_genes.csv:md5,1275096e64e3304019ddfdca21442df3"
-                ]
-            ],
-            [
-                [
-                    "PURECN_RUN",
-                    "PureCN",
-                    "2.12.0"
-                ]
-            ]
-        ],
-        "timestamp": "2026-04-23T14:07:41.478034011",
-        "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.3"
         }
     }
 }

--- a/subworkflows/local/profile_tumor_biomarkers/tests/main.nf.test
+++ b/subworkflows/local/profile_tumor_biomarkers/tests/main.nf.test
@@ -11,13 +11,7 @@ nextflow_workflow {
     tag "typedpyd"
 
 
-    test("profile_tumor_biomarkers - with VCF - stub") {
-
-        options "-stub"
-
-        // PureCN requires specific germline/somatic tags that are difficult to mock manually.
-        // I've implemented the stub as a temporary measure so we can move forward;
-        // we'll transition to a real VCF once the end-to-end test data is available.
+    test("profile_tumor_biomarkers - with VCF ") {
 
         when {
 
@@ -47,7 +41,14 @@ nextflow_workflow {
         then {
             assertAll(
                 { assert workflow.success },
-                { assert snapshot(workflow.out).match() }
+                // PDFs are non-deterministic (R embeds timestamps), so assert existence only
+                { assert workflow.out.purecn_pdf[0][1].every { f -> file(f).exists() } },
+                { assert snapshot(
+                    workflow.out.purecn_csv,
+                    workflow.out.purecn_genes_csv,
+                    workflow.out.dpyd_csv,
+                    workflow.out.dpyd_json
+                ).match() }
             )
         }
     }
@@ -83,7 +84,6 @@ nextflow_workflow {
         then {
             assertAll(
                 { assert workflow.success },
-                // PDFs are non-deterministic (R embeds timestamps), so assert existence only
                 { assert workflow.out.purecn_pdf[0][1].every { f -> file(f).exists() } },
                 { assert snapshot(
                     workflow.out.purecn_csv,
@@ -91,6 +91,44 @@ nextflow_workflow {
                     workflow.out.dpyd_csv,
                     workflow.out.dpyd_json
                 ).match() }
+            )
+        }
+    }
+
+
+    test("profile_tumor_biomarkers - stub") {
+
+        options " -stub "
+
+        when {
+
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id:'test_sample', tumor_id: 'test_tumor' ],
+                    file(params.pipelines_testdata_base_path + 'testdata/purecn/test.paired_end.sorted.cnr', checkIfExists: true)
+                ])
+                input[1] = Channel.of([
+                    [ id:'test_sample', tumor_id: 'test_tumor' ],
+                    file(params.pipelines_testdata_base_path + 'testdata/purecn/test.paired_end.sorted.seg', checkIfExists: true)
+                ])
+                input[2] = Channel.of([
+                    [ : ],
+                    []
+                ])
+                input[3] = Channel.of([
+                    [ id:'test_sample' ],
+                    file(params.pipelines_testdata_base_path + 'testdata/bam/1234T_dedup.bam', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'testdata/bam/1234T_dedup.bai', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(sanitizeOutput(workflow.out)).match() }
             )
         }
     }

--- a/subworkflows/local/profile_tumor_biomarkers/tests/main.nf.test.snap
+++ b/subworkflows/local/profile_tumor_biomarkers/tests/main.nf.test.snap
@@ -1,53 +1,44 @@
 {
-    "profile_tumor_biomarkers - with VCF - stub": {
+    "profile_tumor_biomarkers - with VCF ": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test_sample",
+                        "tumor_id": "test_tumor"
+                    },
+                    "test_sample_purecn.csv:md5,6509c326c007900ef35aed58bfc34d55"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "test_sample.DPYD.csv:md5,4e966b6e924ce8660de4b9a0ed971f07"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test_sample"
+                    },
+                    "test_sample.DPYD.json:md5,4c63101c786af43f474ddfcf561f7ca4"
+                ]
+            ]
+        ],
+        "timestamp": "2026-07-21T17:57:37.459125721",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "26.04.3"
+        }
+    },
+    "profile_tumor_biomarkers - stub": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test_sample",
-                            "tumor_id": "test_tumor"
-                        },
-                        "test_tumor_purecn.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "1": [
-                    
-                ],
-                "2": [
-                    
-                ],
-                "3": [
-                    
-                ],
-                "4": [
-                    [
-                        {
-                            "id": "test_sample",
-                            "tumor_id": "test_tumor"
-                        },
-                        [
-                            "test_tumor_purecn.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "test_tumor_purecn_local_optima.pdf:md5,d41d8cd98f00b204e9800998ecf8427e"
-                        ]
-                    ]
-                ],
-                "5": [
-                    [
-                        {
-                            "id": "test_sample"
-                        },
-                        "test_sample.DPYD.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "6": [
-                    [
-                        {
-                            "id": "test_sample"
-                        },
-                        "test_sample.DPYD.json:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
                 "dpyd_csv": [
                     [
                         {
@@ -70,7 +61,7 @@
                             "id": "test_sample",
                             "tumor_id": "test_tumor"
                         },
-                        "test_tumor_purecn.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test_sample_purecn.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "purecn_genes_csv": [
@@ -86,8 +77,8 @@
                             "tumor_id": "test_tumor"
                         },
                         [
-                            "test_tumor_purecn.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "test_tumor_purecn_local_optima.pdf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                            "test_sample_purecn.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "test_sample_purecn_local_optima.pdf:md5,d41d8cd98f00b204e9800998ecf8427e"
                         ]
                     ]
                 ],
@@ -96,10 +87,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-04-23T18:48:25.233026261",
+        "timestamp": "2026-07-21T17:58:13.434806387",
         "meta": {
             "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.3"
         }
     },
     "profile_tumor_biomarkers - without VCF": {
@@ -110,7 +101,7 @@
                         "id": "test_sample",
                         "tumor_id": "test_tumor"
                     },
-                    "test_tumor_purecn.csv:md5,6509c326c007900ef35aed58bfc34d55"
+                    "test_sample_purecn.csv:md5,6509c326c007900ef35aed58bfc34d55"
                 ]
             ],
             [
@@ -119,7 +110,7 @@
                         "id": "test_sample",
                         "tumor_id": "test_tumor"
                     },
-                    "test_tumor_purecn_genes.csv:md5,1275096e64e3304019ddfdca21442df3"
+                    "test_sample_purecn_genes.csv:md5,a1485ae8fc2e3aa20acb01b9489fbc18"
                 ]
             ],
             [
@@ -139,10 +130,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-04-23T18:48:15.862404283",
+        "timestamp": "2026-07-21T17:58:01.646389351",
         "meta": {
             "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.3"
         }
     }
 }


### PR DESCRIPTION
### Fixed

- Replaced the stubbed `PURECN_RUN` and `PROFILE_TUMOR_BIOMARKERS` nf-tests with real-VCF runs and added dedicated stub cases.
- Dropped the mocked `tumor_id` meta key so tests use the `meta.id`-based output prefix (aligns with #56).
- PDF outputs are asserted for existence only (R embeds non-deterministic timestamps); conditional CSVs are snapshotted where produced.
- Regenerated the snapshot files for both tests.
