### PR TITLE
fix: pass ZipperBams tag options via ext.args2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Initial release of genomic-medicine-sweden/autoseq, created with the [nf-core](h
 - [ #58 ](https://github.com/genomic-medicine-sweden/autoseq/pull/58) Replaced the stubbed `PURECN_RUN` and `PROFILE_TUMOR_BIOMARKERS` nf-tests with real-VCF runs, added dedicated stub cases, and regenerated the snapshots.
 - [ #59 ](https://github.com/genomic-medicine-sweden/autoseq/pull/59) Added `--normal-sample ${meta.normal_id}` to `GATK4_MUTECT2` so the normal sample is correctly identified in paired tumor/normal calling.
 - [ #62 ](https://github.com/genomic-medicine-sweden/autoseq/pull/62) Excluded non-deterministic Jumble CNV outputs from the `tests/default.nf.test` content snapshot to fix md5 failures in CI.
+- [ #73 ](https://github.com/genomic-medicine-sweden/autoseq/pull/73) Moved the `ZIPPERBAMS_(PRE|POST)` tag options from `ext.args` to `ext.args2` so they are passed to `ZipperBams` instead of to the fgbio wrapper.
 
 ### `Dependencies`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -59,7 +59,8 @@ process {
     }
 
     withName: '.*:UMI_PROCESSING:ZIPPERBAMS_(PRE|POST)' {
-        ext.args = { "--tags-to-reverse Consensus --tags-to-revcomp Consensus" }
+        // ZipperBams tool options go in ext.args2 — ext.args holds fgbio common options
+        ext.args2 = { "--tags-to-reverse Consensus --tags-to-revcomp Consensus" }
     }
 
     withName: '.*:UMI_PROCESSING:FILTERCONSENSUS' {


### PR DESCRIPTION
### Fixed

- The `--tags-to-reverse`/`--tags-to-revcomp` options for `ZIPPERBAMS_(PRE|POST)` were set in `ext.args`, which the fgbio module interpolates *before* the `ZipperBams` subcommand — that position is reserved for fgbio common options. Moved them to `ext.args2`, which is interpolated after the subcommand where tool options belong.