### PR TITLE
fix: collect reference channel for UMI_PROCESSING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Initial release of genomic-medicine-sweden/autoseq, created with the [nf-core](h
 - [ #58 ](https://github.com/genomic-medicine-sweden/autoseq/pull/58) Replaced the stubbed `PURECN_RUN` and `PROFILE_TUMOR_BIOMARKERS` nf-tests with real-VCF runs, added dedicated stub cases, and regenerated the snapshots.
 - [ #59 ](https://github.com/genomic-medicine-sweden/autoseq/pull/59) Added `--normal-sample ${meta.normal_id}` to `GATK4_MUTECT2` so the normal sample is correctly identified in paired tumor/normal calling.
 - [ #62 ](https://github.com/genomic-medicine-sweden/autoseq/pull/62) Excluded non-deterministic Jumble CNV outputs from the `tests/default.nf.test` content snapshot to fix md5 failures in CI.
+- [ #74 ](https://github.com/genomic-medicine-sweden/autoseq/pull/74) Collected the reference channel passed to `UMI_PROCESSING` so it is reusable across all samples instead of being consumed by the first one.
 
 ### `Dependencies`
 

--- a/workflows/autoseq.nf
+++ b/workflows/autoseq.nf
@@ -112,12 +112,15 @@ workflow AUTOSEQ {
             ch_input_reads
         )
 
+        // `.collect()` restores the value-channel semantics lost by `combine`, so that the
+        // reference can be reused by every sample inside UMI_PROCESSING
         def ch_fasta_fai_dict = ch_genome_fasta
             .combine(ch_genome_fai)
             .combine(ch_dict)
             .map { meta, fasta, _meta_fai, fai, _meta_dict, dict ->
                 [meta, fasta, fai, dict]
             }
+            .collect()
 
         UMI_PROCESSING(
             CAT_FASTQ.out.reads,


### PR DESCRIPTION
### Fixed

- `combine` turns the genome reference value channels into a queue channel, so `ch_fasta_fai_dict` emitted a single item that the first sample consumed — leaving later samples with no reference. Added `.collect()` to restore value-channel semantics so every sample inside `UMI_PROCESSING` can reuse it.