### PR TITLE
test: add nf-test for call_cnvs subworkflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Initial release of genomic-medicine-sweden/autoseq, created with the [nf-core](h
 - [ #50 ](https://github.com/genomic-medicine-sweden/autoseq/pull/50) Added `PREPARE_REFERENCES` subworkflow to build the BWA-MEM2 index and untar the VEP cache, GRIDSS index and HMF ensembl_data references, with nf-test coverage.
 - [ #55 ](https://github.com/genomic-medicine-sweden/autoseq/pull/55) Enabled an end-to-end `-profile test` run of the paired tumor/normal workflow on real GRCh37 test data.
 - [ #71 ](https://github.com/genomic-medicine-sweden/autoseq/pull/71) Added a `test_umi` profile and pipeline-level nf-test covering the UMI alignment branch on paired tumor/normal test data.
+- [ #87 ](https://github.com/genomic-medicine-sweden/autoseq/pull/87) Added nf-test and `meta.yml` for the `CALL_CNVS` subworkflow covering paired tumor/normal samples and a stub case.
 
 ### `Changed`
 

--- a/subworkflows/local/call_cnvs/meta.yml
+++ b/subworkflows/local/call_cnvs/meta.yml
@@ -1,0 +1,79 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+name: "call_cnvs"
+description: Call copy number variants from aligned BAM files with Jumble and annotate the resulting segments with cancer relevant genes
+keywords:
+  - cnv
+  - copy number
+  - jumble
+  - annotation
+components:
+  - jumble
+  - annotate_cnvs
+input:
+  - ch_input_bam:
+      type: file
+      description: |
+        Aligned, deduplicated BAM files with their indices. `meta.sample_type`
+        decides whether the segments are annotated as somatic (`tumor`) or
+        germline (`normal`).
+        Structure: [ val(meta), path(bam), path(bai) ]
+      pattern: "*.bam"
+  - ch_jumble_ref:
+      type: file
+      description: |
+        Panel-specific Jumble reference built from a set of normal samples
+        Structure: [ val(meta), path(rds) ]
+      pattern: "*.RDS"
+  - ch_curation_ann:
+      type: file
+      description: |
+        Cancer gene annotation table used to annotate the called segments
+        Structure: [ val(meta), path(csv) ]
+      pattern: "*.csv"
+output:
+  - jumble_cns:
+      type: file
+      description: |
+        Called copy number segments
+        Structure: [ val(meta), path(cns) ]
+      pattern: "*.cns"
+  - cnr:
+      type: file
+      description: |
+        Bin-level copy number ratios
+        Structure: [ val(meta), path(cnr) ]
+      pattern: "*.cnr"
+  - seg:
+      type: file
+      description: |
+        DNAcopy segmentation table
+        Structure: [ val(meta), path(seg) ]
+      pattern: "*_dnacopy.seg"
+  - profile_bedgraph:
+      type: file
+      description: |
+        Bin-level copy number profile in bedGraph format for IGV
+        Structure: [ val(meta), path(bedgraph) ]
+      pattern: "*_profile.bedgraph"
+  - segments_bedgraph:
+      type: file
+      description: |
+        Segment-level copy number calls in bedGraph format for IGV
+        Structure: [ val(meta), path(bedgraph) ]
+      pattern: "*_segments.bedgraph"
+  - png:
+      type: file
+      description: |
+        Copy number profile plot
+        Structure: [ val(meta), path(png) ]
+      pattern: "*.png"
+  - cns:
+      type: file
+      description: |
+        Copy number segments annotated with cancer relevant genes
+        Structure: [ val(meta), path(cns) ]
+      pattern: "*_ann.cns"
+authors:
+  - "@imsarath"
+maintainers:
+  - "@imsarath"

--- a/subworkflows/local/call_cnvs/tests/main.nf.test
+++ b/subworkflows/local/call_cnvs/tests/main.nf.test
@@ -1,0 +1,101 @@
+nextflow_workflow {
+
+    name "Test Subworkflow CALL_CNVS"
+    script "../main.nf"
+    workflow "CALL_CNVS"
+    config "./nextflow.config"
+
+    tag "subworkflows"
+    tag "subworkflows_local"
+    tag "subworkflows/call_cnvs"
+    tag "jumble"
+    tag "annotate_cnvs"
+
+    test("tumor and normal samples") {
+
+        when {
+            workflow {
+                """
+                input[0] = channel.of(
+                    [
+                        [ id:'TUMOR', case_id:'TEST', sample_name:'TUMOR', sample_type:'tumor' ],
+                        file(params.pipelines_testdata_base_path + 'testdata/bam/TUMOR_dedup.bam', checkIfExists: true),
+                        file(params.pipelines_testdata_base_path + 'testdata/bam/TUMOR_dedup.bai', checkIfExists: true)
+                    ],
+                    [
+                        [ id:'NORMAL', case_id:'TEST', sample_name:'NORMAL', sample_type:'normal' ],
+                        file(params.pipelines_testdata_base_path + 'testdata/bam/NORMAL_dedup.bam', checkIfExists: true),
+                        file(params.pipelines_testdata_base_path + 'testdata/bam/NORMAL_dedup.bai', checkIfExists: true)
+                    ]
+                )
+                input[1] = channel.value([
+                    [ id:'test_panel' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/targets/test_panel.bed.reference.RDS', checkIfExists: true)
+                ])
+                input[2] = channel.value([
+                    [ id:'curation_ann' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/annotations/cancer_gene_annotations_for_curation.37.v2.csv', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    workflow.out.jumble_cns,
+                    workflow.out.segments_bedgraph,
+                    // `_ann.cns` is annotated as somatic for the tumor sample and germline for
+                    // the normal sample, so the routing on `meta.sample_type` is covered here
+                    workflow.out.cns,
+                    // Jumble writes per-run values into the plots and the bin-level outputs,
+                    // so only their file names are asserted
+                    workflow.out.cnr.collect { meta, cnr -> [meta, file(cnr).name] },
+                    workflow.out.seg.collect { meta, seg -> [meta, file(seg).name] },
+                    workflow.out.profile_bedgraph.collect { meta, bedgraph -> [meta, file(bedgraph).name] },
+                    workflow.out.png.collect { meta, png -> [meta, file(png).name] }
+                ).match() }
+            )
+        }
+    }
+
+    test("tumor and normal samples - stub") {
+
+        options "-stub"
+
+        when {
+            workflow {
+                """
+                input[0] = channel.of(
+                    [
+                        [ id:'TUMOR', case_id:'TEST', sample_name:'TUMOR', sample_type:'tumor' ],
+                        file(params.pipelines_testdata_base_path + 'testdata/bam/TUMOR_dedup.bam', checkIfExists: true),
+                        file(params.pipelines_testdata_base_path + 'testdata/bam/TUMOR_dedup.bai', checkIfExists: true)
+                    ],
+                    [
+                        [ id:'NORMAL', case_id:'TEST', sample_name:'NORMAL', sample_type:'normal' ],
+                        file(params.pipelines_testdata_base_path + 'testdata/bam/NORMAL_dedup.bam', checkIfExists: true),
+                        file(params.pipelines_testdata_base_path + 'testdata/bam/NORMAL_dedup.bai', checkIfExists: true)
+                    ]
+                )
+                input[1] = channel.value([
+                    [ id:'test_panel' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/targets/test_panel.bed.reference.RDS', checkIfExists: true)
+                ])
+                input[2] = channel.value([
+                    [ id:'curation_ann' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/annotations/cancer_gene_annotations_for_curation.37.v2.csv', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(sanitizeOutput(workflow.out)).match() }
+            )
+        }
+    }
+}

--- a/subworkflows/local/call_cnvs/tests/main.nf.test.snap
+++ b/subworkflows/local/call_cnvs/tests/main.nf.test.snap
@@ -1,0 +1,302 @@
+{
+    "tumor and normal samples - stub": {
+        "content": [
+            {
+                "cnr": [
+                    [
+                        {
+                            "id": "NORMAL",
+                            "case_id": "TEST",
+                            "sample_name": "NORMAL",
+                            "sample_type": "normal"
+                        },
+                        "NORMAL.cnr:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ],
+                    [
+                        {
+                            "id": "TUMOR",
+                            "case_id": "TEST",
+                            "sample_name": "TUMOR",
+                            "sample_type": "tumor"
+                        },
+                        "TUMOR.cnr:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "cns": [
+                    [
+                        {
+                            "id": "NORMAL",
+                            "case_id": "TEST",
+                            "sample_name": "NORMAL",
+                            "sample_type": "normal"
+                        },
+                        "NORMAL_ann.cns:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ],
+                    [
+                        {
+                            "id": "TUMOR",
+                            "case_id": "TEST",
+                            "sample_name": "TUMOR",
+                            "sample_type": "tumor"
+                        },
+                        "TUMOR_ann.cns:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "jumble_cns": [
+                    [
+                        {
+                            "id": "NORMAL",
+                            "case_id": "TEST",
+                            "sample_name": "NORMAL",
+                            "sample_type": "normal"
+                        },
+                        "NORMAL.cns:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ],
+                    [
+                        {
+                            "id": "TUMOR",
+                            "case_id": "TEST",
+                            "sample_name": "TUMOR",
+                            "sample_type": "tumor"
+                        },
+                        "TUMOR.cns:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "png": [
+                    [
+                        {
+                            "id": "NORMAL",
+                            "case_id": "TEST",
+                            "sample_name": "NORMAL",
+                            "sample_type": "normal"
+                        },
+                        "NORMAL.png:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ],
+                    [
+                        {
+                            "id": "TUMOR",
+                            "case_id": "TEST",
+                            "sample_name": "TUMOR",
+                            "sample_type": "tumor"
+                        },
+                        "TUMOR.png:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "profile_bedgraph": [
+                    [
+                        {
+                            "id": "NORMAL",
+                            "case_id": "TEST",
+                            "sample_name": "NORMAL",
+                            "sample_type": "normal"
+                        },
+                        "NORMAL_profile.bedgraph:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ],
+                    [
+                        {
+                            "id": "TUMOR",
+                            "case_id": "TEST",
+                            "sample_name": "TUMOR",
+                            "sample_type": "tumor"
+                        },
+                        "TUMOR_profile.bedgraph:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "seg": [
+                    [
+                        {
+                            "id": "NORMAL",
+                            "case_id": "TEST",
+                            "sample_name": "NORMAL",
+                            "sample_type": "normal"
+                        },
+                        "NORMAL_dnacopy.seg:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ],
+                    [
+                        {
+                            "id": "TUMOR",
+                            "case_id": "TEST",
+                            "sample_name": "TUMOR",
+                            "sample_type": "tumor"
+                        },
+                        "TUMOR_dnacopy.seg:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "segments_bedgraph": [
+                    [
+                        {
+                            "id": "NORMAL",
+                            "case_id": "TEST",
+                            "sample_name": "NORMAL",
+                            "sample_type": "normal"
+                        },
+                        "NORMAL_segments.bedgraph:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ],
+                    [
+                        {
+                            "id": "TUMOR",
+                            "case_id": "TEST",
+                            "sample_name": "TUMOR",
+                            "sample_type": "tumor"
+                        },
+                        "TUMOR_segments.bedgraph:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-08-10T13:58:41.384568163",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "26.04.6"
+        }
+    },
+    "tumor and normal samples": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "NORMAL",
+                        "case_id": "TEST",
+                        "sample_name": "NORMAL",
+                        "sample_type": "normal"
+                    },
+                    "NORMAL.cns:md5,05b74f7bb5bc72879ab382fa07187227"
+                ],
+                [
+                    {
+                        "id": "TUMOR",
+                        "case_id": "TEST",
+                        "sample_name": "TUMOR",
+                        "sample_type": "tumor"
+                    },
+                    "TUMOR.cns:md5,86dd10fb9bba9d4627c72da10f0e051f"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "NORMAL",
+                        "case_id": "TEST",
+                        "sample_name": "NORMAL",
+                        "sample_type": "normal"
+                    },
+                    "NORMAL_segments.bedgraph:md5,3403ab6b1c036d688b79a1aae937be89"
+                ],
+                [
+                    {
+                        "id": "TUMOR",
+                        "case_id": "TEST",
+                        "sample_name": "TUMOR",
+                        "sample_type": "tumor"
+                    },
+                    "TUMOR_segments.bedgraph:md5,e1826f8163e12facfc620c07f370c0e3"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "NORMAL",
+                        "case_id": "TEST",
+                        "sample_name": "NORMAL",
+                        "sample_type": "normal"
+                    },
+                    "NORMAL_ann.cns:md5,3aa49cf3093d9d0fbe3f57ca10c4b785"
+                ],
+                [
+                    {
+                        "id": "TUMOR",
+                        "case_id": "TEST",
+                        "sample_name": "TUMOR",
+                        "sample_type": "tumor"
+                    },
+                    "TUMOR_ann.cns:md5,86284c73bb11714625b718c5f8ee94ef"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "NORMAL",
+                        "case_id": "TEST",
+                        "sample_name": "NORMAL",
+                        "sample_type": "normal"
+                    },
+                    "NORMAL.cnr"
+                ],
+                [
+                    {
+                        "id": "TUMOR",
+                        "case_id": "TEST",
+                        "sample_name": "TUMOR",
+                        "sample_type": "tumor"
+                    },
+                    "TUMOR.cnr"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "NORMAL",
+                        "case_id": "TEST",
+                        "sample_name": "NORMAL",
+                        "sample_type": "normal"
+                    },
+                    "NORMAL_dnacopy.seg"
+                ],
+                [
+                    {
+                        "id": "TUMOR",
+                        "case_id": "TEST",
+                        "sample_name": "TUMOR",
+                        "sample_type": "tumor"
+                    },
+                    "TUMOR_dnacopy.seg"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "NORMAL",
+                        "case_id": "TEST",
+                        "sample_name": "NORMAL",
+                        "sample_type": "normal"
+                    },
+                    "NORMAL_profile.bedgraph"
+                ],
+                [
+                    {
+                        "id": "TUMOR",
+                        "case_id": "TEST",
+                        "sample_name": "TUMOR",
+                        "sample_type": "tumor"
+                    },
+                    "TUMOR_profile.bedgraph"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "NORMAL",
+                        "case_id": "TEST",
+                        "sample_name": "NORMAL",
+                        "sample_type": "normal"
+                    },
+                    "NORMAL.png"
+                ],
+                [
+                    {
+                        "id": "TUMOR",
+                        "case_id": "TEST",
+                        "sample_name": "TUMOR",
+                        "sample_type": "tumor"
+                    },
+                    "TUMOR.png"
+                ]
+            ]
+        ],
+        "timestamp": "2026-08-10T13:58:32.145002661",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "26.04.6"
+        }
+    }
+}

--- a/subworkflows/local/call_cnvs/tests/nextflow.config
+++ b/subworkflows/local/call_cnvs/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: '.*CALL_CNVS:ANNOTATE_CNVS' {
+        ext.args = { "--cancer-type ${params.cancer_type}" }
+    }
+}


### PR DESCRIPTION
### Added

- nf-test for the `CALL_CNVS` subworkflow covering a tumor and a normal sample, including the somatic/germline routing of `ANNOTATE_CNVS`
- `meta.yml` for the `CALL_CNVS` subworkflow

Closes #65