### PR TITLE
test: add nf-test for call_germline_snvs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Initial release of genomic-medicine-sweden/autoseq, created with the [nf-core](h
 - [ #50 ](https://github.com/genomic-medicine-sweden/autoseq/pull/50) Added `PREPARE_REFERENCES` subworkflow to build the BWA-MEM2 index and untar the VEP cache, GRIDSS index and HMF ensembl_data references, with nf-test coverage.
 - [ #55 ](https://github.com/genomic-medicine-sweden/autoseq/pull/55) Enabled an end-to-end `-profile test` run of the paired tumor/normal workflow on real GRCh37 test data.
 - [ #71 ](https://github.com/genomic-medicine-sweden/autoseq/pull/71) Added a `test_umi` profile and pipeline-level nf-test covering the UMI alignment branch on paired tumor/normal test data.
+- [ #88 ](https://github.com/genomic-medicine-sweden/autoseq/pull/88) Added nf-test and `meta.yml` for the `CALL_GERMLINE_SNVS` subworkflow covering a normal sample with the panel interval list and a stub case.
 
 ### `Changed`
 

--- a/subworkflows/local/call_germline_snvs/meta.yml
+++ b/subworkflows/local/call_germline_snvs/meta.yml
@@ -1,0 +1,84 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+name: "call_germline_snvs"
+description: Call germline SNVs and indels from a normal sample with GATK HaplotypeCaller and annotate them with Ensembl VEP
+keywords:
+  - germline
+  - snv
+  - haplotypecaller
+  - annotation
+  - vep
+components:
+  - gatk4/haplotypecaller
+  - ensemblvep/vep
+input:
+  - ch_input:
+      type: file
+      description: |
+        Aligned, deduplicated BAM of the normal sample with its index, the intervals
+        to restrict calling to and an optional DragSTR model
+        Structure: [ val(meta), path(bam), path(bai), path(intervals), path(dragstr_model) ]
+      pattern: "*.bam"
+  - ch_genome_fasta:
+      type: file
+      description: |
+        Reference genome FASTA
+        Structure: [ val(meta), path(fasta) ]
+      pattern: "*.{fa,fasta}"
+  - ch_genome_fai:
+      type: file
+      description: |
+        Index of the reference genome FASTA
+        Structure: [ val(meta), path(fai) ]
+      pattern: "*.fai"
+  - ch_dict:
+      type: file
+      description: |
+        Sequence dictionary of the reference genome
+        Structure: [ val(meta), path(dict) ]
+      pattern: "*.dict"
+  - ch_vep_cache:
+      type: directory
+      description: |
+        Ensembl VEP cache directory
+        Structure: [ val(meta), path(cache) ]
+  - ch_dbsnp_vcf:
+      type: file
+      description: |
+        dbSNP VCF used to annotate the called variants with rsIDs
+        Structure: [ val(meta), path(vcf) ]
+      pattern: "*.vcf.gz"
+  - ch_dbsnp_vcf_tbi:
+      type: file
+      description: |
+        Index of the dbSNP VCF
+        Structure: [ val(meta), path(tbi) ]
+      pattern: "*.vcf.gz.tbi"
+output:
+  - vcf:
+      type: file
+      description: |
+        Germline variants called by HaplotypeCaller
+        Structure: [ val(meta), path(vcf) ]
+      pattern: "*.vcf.gz"
+  - tbi:
+      type: file
+      description: |
+        Index of the HaplotypeCaller VCF
+        Structure: [ val(meta), path(tbi) ]
+      pattern: "*.vcf.gz.tbi"
+  - vep_vcf:
+      type: file
+      description: |
+        Germline variants annotated with Ensembl VEP
+        Structure: [ val(meta), path(vcf) ]
+      pattern: "*.vcf.gz"
+  - vep_tbi:
+      type: file
+      description: |
+        Index of the VEP annotated VCF
+        Structure: [ val(meta), path(tbi) ]
+      pattern: "*.vcf.gz.tbi"
+authors:
+  - "@imsarath"
+maintainers:
+  - "@imsarath"

--- a/subworkflows/local/call_germline_snvs/tests/main.nf.test
+++ b/subworkflows/local/call_germline_snvs/tests/main.nf.test
@@ -71,9 +71,9 @@ nextflow_workflow {
                 { assert snapshot(
                     // GATK and VEP write the tool version and the full command line into the
                     // VCF header, so only the variant records are hashed
-                    workflow.out.vcf.collect { meta, vcf -> [meta, path(vcf).vcf.variantsMD5] },
+                    workflow.out.vcf.collect { meta, vcf -> [meta, "${file(vcf).name}:${path(vcf).vcf.variantsMD5}"] },
                     workflow.out.tbi.collect { meta, tbi -> [meta, file(tbi).name] },
-                    workflow.out.vep_vcf.collect { meta, vcf -> [meta, path(vcf).vcf.variantsMD5] },
+                    workflow.out.vep_vcf.collect { meta, vcf -> [meta, "${file(vcf).name}:${path(vcf).vcf.variantsMD5}"] },
                     workflow.out.vep_tbi.collect { meta, tbi -> [meta, file(tbi).name] }
                 ).match() }
             )

--- a/subworkflows/local/call_germline_snvs/tests/main.nf.test
+++ b/subworkflows/local/call_germline_snvs/tests/main.nf.test
@@ -1,0 +1,136 @@
+nextflow_workflow {
+
+    name "Test Subworkflow CALL_GERMLINE_SNVS"
+    script "../main.nf"
+    workflow "CALL_GERMLINE_SNVS"
+    config "./nextflow.config"
+
+    tag "subworkflows"
+    tag "subworkflows_local"
+    tag "subworkflows/call_germline_snvs"
+    tag "gatk4"
+    tag "gatk4/haplotypecaller"
+    tag "ensemblvep"
+    tag "ensemblvep/vep"
+    tag "untar"
+
+    setup {
+        run("UNTAR") {
+            script "../../../../modules/nf-core/untar/main.nf"
+            process {
+                """
+                input[0] = channel.of([
+                    [ id:'vep_cache' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/vep.tar.gz', checkIfExists: true)
+                ])
+                """
+            }
+        }
+    }
+
+    test("normal sample with panel intervals") {
+
+        when {
+            workflow {
+                """
+                input[0] = channel.of([
+                    [ id:'NORMAL', case_id:'TEST', sample_name:'NORMAL', sample_type:'normal' ],
+                    file(params.pipelines_testdata_base_path + 'testdata/bam/NORMAL_dedup.bam', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'testdata/bam/NORMAL_dedup.bai', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/targets/test_panel.targets.slopped20.interval_list', checkIfExists: true),
+                    []
+                ])
+                input[1] = channel.value([
+                    [ id:'genome' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.fasta', checkIfExists: true)
+                ])
+                input[2] = channel.value([
+                    [ id:'genome_fai' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.fasta.fai', checkIfExists: true)
+                ])
+                input[3] = channel.value([
+                    [ id:'genome_dict' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.dict', checkIfExists: true)
+                ])
+                input[4] = UNTAR.out.untar.collect()
+                input[5] = channel.value([
+                    [ id:'dbsnp_vcf' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/annotations/dbsnp_138.b37.vcf.gz', checkIfExists: true)
+                ])
+                input[6] = channel.value([
+                    [ id:'dbsnp_vcf_tbi' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/annotations/dbsnp_138.b37.vcf.gz.tbi', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    // GATK and VEP write the tool version and the full command line into the
+                    // VCF header, so only the variant records are hashed
+                    workflow.out.vcf.collect { meta, vcf -> [meta, path(vcf).vcf.variantsMD5] },
+                    workflow.out.tbi.collect { meta, tbi -> [meta, file(tbi).name] },
+                    workflow.out.vep_vcf.collect { meta, vcf -> [meta, path(vcf).vcf.variantsMD5] },
+                    workflow.out.vep_tbi.collect { meta, tbi -> [meta, file(tbi).name] }
+                ).match() }
+            )
+        }
+    }
+
+    test("normal sample with panel intervals - stub") {
+
+        options "-stub"
+
+        when {
+            workflow {
+                """
+                input[0] = channel.of([
+                    [ id:'NORMAL', case_id:'TEST', sample_name:'NORMAL', sample_type:'normal' ],
+                    file(params.pipelines_testdata_base_path + 'testdata/bam/NORMAL_dedup.bam', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'testdata/bam/NORMAL_dedup.bai', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/targets/test_panel.targets.slopped20.interval_list', checkIfExists: true),
+                    []
+                ])
+                input[1] = channel.value([
+                    [ id:'genome' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.fasta', checkIfExists: true)
+                ])
+                input[2] = channel.value([
+                    [ id:'genome_fai' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.fasta.fai', checkIfExists: true)
+                ])
+                input[3] = channel.value([
+                    [ id:'genome_dict' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.dict', checkIfExists: true)
+                ])
+                input[4] = UNTAR.out.untar.collect()
+                input[5] = channel.value([
+                    [ id:'dbsnp_vcf' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/annotations/dbsnp_138.b37.vcf.gz', checkIfExists: true)
+                ])
+                input[6] = channel.value([
+                    [ id:'dbsnp_vcf_tbi' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/annotations/dbsnp_138.b37.vcf.gz.tbi', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                // the empty `.vcf.gz` written by the GATK stub cannot be decompressed and
+                // is serialised as an absolute work path, so only the file names are asserted
+                { assert snapshot(
+                    workflow.out.vcf.collect { meta, vcf -> [meta, file(vcf).name] },
+                    workflow.out.tbi.collect { meta, tbi -> [meta, file(tbi).name] },
+                    workflow.out.vep_vcf.collect { meta, vcf -> [meta, file(vcf).name] },
+                    workflow.out.vep_tbi.collect { meta, tbi -> [meta, file(tbi).name] }
+                ).match() }
+            )
+        }
+    }
+}

--- a/subworkflows/local/call_germline_snvs/tests/main.nf.test.snap
+++ b/subworkflows/local/call_germline_snvs/tests/main.nf.test.snap
@@ -62,7 +62,7 @@
                         "sample_name": "NORMAL",
                         "sample_type": "normal"
                     },
-                    "52b988e94f0b29a95e76ba24a654ac5c"
+                    "NORMAL_haplotypecaller.vcf.gz:52b988e94f0b29a95e76ba24a654ac5c"
                 ]
             ],
             [
@@ -84,7 +84,7 @@
                         "sample_name": "NORMAL",
                         "sample_type": "normal"
                     },
-                    "d41d8cd98f00b204e9800998ecf8427e"
+                    "NORMAL-all.germline.vep.vcf.gz:d41d8cd98f00b204e9800998ecf8427e"
                 ]
             ],
             [
@@ -99,7 +99,7 @@
                 ]
             ]
         ],
-        "timestamp": "2026-08-10T14:16:49.423664698",
+        "timestamp": "2026-08-13T14:21:00.73870608",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "26.04.6"

--- a/subworkflows/local/call_germline_snvs/tests/main.nf.test.snap
+++ b/subworkflows/local/call_germline_snvs/tests/main.nf.test.snap
@@ -1,0 +1,108 @@
+{
+    "normal sample with panel intervals - stub": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "NORMAL",
+                        "case_id": "TEST",
+                        "sample_name": "NORMAL",
+                        "sample_type": "normal"
+                    },
+                    "NORMAL_haplotypecaller.vcf.gz"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "NORMAL",
+                        "case_id": "TEST",
+                        "sample_name": "NORMAL",
+                        "sample_type": "normal"
+                    },
+                    "NORMAL_haplotypecaller.vcf.gz.tbi"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "NORMAL",
+                        "case_id": "TEST",
+                        "sample_name": "NORMAL",
+                        "sample_type": "normal"
+                    },
+                    "NORMAL-all.germline.vep.vcf.gz"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "NORMAL",
+                        "case_id": "TEST",
+                        "sample_name": "NORMAL",
+                        "sample_type": "normal"
+                    },
+                    "NORMAL-all.germline.vep.vcf.gz.tbi"
+                ]
+            ]
+        ],
+        "timestamp": "2026-08-10T14:22:34.250556764",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "26.04.6"
+        }
+    },
+    "normal sample with panel intervals": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "NORMAL",
+                        "case_id": "TEST",
+                        "sample_name": "NORMAL",
+                        "sample_type": "normal"
+                    },
+                    "52b988e94f0b29a95e76ba24a654ac5c"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "NORMAL",
+                        "case_id": "TEST",
+                        "sample_name": "NORMAL",
+                        "sample_type": "normal"
+                    },
+                    "NORMAL_haplotypecaller.vcf.gz.tbi"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "NORMAL",
+                        "case_id": "TEST",
+                        "sample_name": "NORMAL",
+                        "sample_type": "normal"
+                    },
+                    "d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "NORMAL",
+                        "case_id": "TEST",
+                        "sample_name": "NORMAL",
+                        "sample_type": "normal"
+                    },
+                    "NORMAL-all.germline.vep.vcf.gz.tbi"
+                ]
+            ]
+        ],
+        "timestamp": "2026-08-10T14:16:49.423664698",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "26.04.6"
+        }
+    }
+}

--- a/subworkflows/local/call_germline_snvs/tests/nextflow.config
+++ b/subworkflows/local/call_germline_snvs/tests/nextflow.config
@@ -1,0 +1,11 @@
+process {
+    withName: '.*CALL_GERMLINE_SNVS:GATK4_HAPLOTYPECALLER' {
+        ext.prefix = { "${meta.sample_name}_haplotypecaller" }
+    }
+
+    withName: '.*CALL_GERMLINE_SNVS:ENSEMBLVEP_VEP' {
+        ext.args = { "--vcf --pick --filter_common --check_existing --total_length --allele_number --no_escape --no_stats --everything --offline" }
+        ext.args2 = { "-p vcf" }
+        ext.prefix = { "${meta.sample_name}-all.germline.vep" }
+    }
+}


### PR DESCRIPTION
### Added

- nf-test for the `CALL_GERMLINE_SNVS` subworkflow covering a normal sample with the panel interval list and a stub case.
- `meta.yml` describing the subworkflow inputs and outputs.

Closes #66