### PR TITLE
test: add nf-test for call_svs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Initial release of genomic-medicine-sweden/autoseq, created with the [nf-core](h
 - [ #50 ](https://github.com/genomic-medicine-sweden/autoseq/pull/50) Added `PREPARE_REFERENCES` subworkflow to build the BWA-MEM2 index and untar the VEP cache, GRIDSS index and HMF ensembl_data references, with nf-test coverage.
 - [ #55 ](https://github.com/genomic-medicine-sweden/autoseq/pull/55) Enabled an end-to-end `-profile test` run of the paired tumor/normal workflow on real GRCh37 test data.
 - [ #71 ](https://github.com/genomic-medicine-sweden/autoseq/pull/71) Added a `test_umi` profile and pipeline-level nf-test covering the UMI alignment branch on paired tumor/normal test data.
+- [ #89 ](https://github.com/genomic-medicine-sweden/autoseq/pull/89) Added nf-test and `meta.yml` for the `CALL_SVS` subworkflow covering a paired tumor/normal case and a stub case.
 
 ### `Changed`
 

--- a/subworkflows/local/call_svs/meta.yml
+++ b/subworkflows/local/call_svs/meta.yml
@@ -1,0 +1,120 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+name: "call_svs"
+description: Call structural variants from a paired tumor/normal case with GRIDSS and filter them into somatic and germline call sets with GRIPSS
+keywords:
+  - structural variants
+  - sv
+  - gridss
+  - gripss
+components:
+  - gridss/extract_overlapping_fragments
+  - gridss/preprocess
+  - gridss/assemble
+  - gridss/call
+  - gripss/somatic
+  - gripss/germline
+input:
+  - ch_aligned_bam:
+      type: file
+      description: |
+        Aligned, deduplicated BAM files with their indices. Tumor and normal samples
+        are paired on `meta.case_id` before the assemble step.
+        Structure: [ val(meta), path(bam), path(bai) ]
+      pattern: "*.bam"
+  - ch_genome_fasta:
+      type: file
+      description: |
+        Reference genome FASTA
+        Structure: [ val(meta), path(fasta) ]
+      pattern: "*.{fa,fasta}"
+  - ch_genome_fai:
+      type: file
+      description: |
+        Index of the reference genome FASTA
+        Structure: [ val(meta), path(fai) ]
+      pattern: "*.fai"
+  - ch_genome_gridss_index:
+      type: directory
+      description: |
+        Directory holding the BWA and GRIDSS indices of the reference genome
+        Structure: [ val(meta), path(index) ]
+  - ch_genome_dict:
+      type: file
+      description: |
+        Sequence dictionary of the reference genome
+        Structure: [ val(meta), path(dict) ]
+      pattern: "*.dict"
+  - ch_pon_breakends:
+      type: file
+      description: |
+        Panel of normals of single breakends
+        Structure: [ val(meta), path(bed) ]
+      pattern: "*.bed.gz"
+  - ch_pon_breakpoints:
+      type: file
+      description: |
+        Panel of normals of breakpoints
+        Structure: [ val(meta), path(bedpe) ]
+      pattern: "*.bedpe.gz"
+  - ch_known_fusions:
+      type: file
+      description: |
+        Known fusion breakpoints rescued during filtering
+        Structure: [ val(meta), path(bedpe) ]
+      pattern: "*.bedpe"
+  - ch_repeatmasker_annotations:
+      type: file
+      description: |
+        RepeatMasker annotations used to flag repeat driven calls
+        Structure: [ val(meta), path(fasta) ]
+      pattern: "*.fa.gz"
+  - ch_target_region_bed:
+      type: file
+      description: |
+        Target panel BED used to extract overlapping fragments and to restrict filtering
+        Structure: [ val(meta), path(bed) ]
+      pattern: "*.bed"
+  - ch_gridss_config:
+      type: file
+      description: |
+        GRIDSS configuration properties
+        Structure: [ val(meta), path(properties) ]
+      pattern: "*.properties"
+  - genome_version:
+      type: string
+      description: Numeric reference genome version passed to GRIPSS ('37' or '38')
+output:
+  - gridss_vcf:
+      type: file
+      description: |
+        Unfiltered structural variants called by GRIDSS for the case
+        Structure: [ val(meta), path(vcf) ]
+      pattern: "*.sv.gridss.vcf.gz"
+  - gripss_somatic_filtered_vcf:
+      type: file
+      description: |
+        Somatic structural variants passing the GRIPSS filters, with index
+        Structure: [ val(meta), path(vcf), path(tbi) ]
+      pattern: "*.gripss.filtered.somatic.vcf.gz"
+  - gripss_somatic_unfiltered_vcf:
+      type: file
+      description: |
+        All somatic structural variants with their GRIPSS filter annotations, with index
+        Structure: [ val(meta), path(vcf), path(tbi) ]
+      pattern: "*.gripss.somatic.vcf.gz"
+  - gripss_germline_filtered_vcf:
+      type: file
+      description: |
+        Germline structural variants passing the GRIPSS filters, with index
+        Structure: [ val(meta), path(vcf), path(tbi) ]
+      pattern: "*.gripss.filtered.germline.vcf.gz"
+  - gripss_germline_unfiltered_vcf:
+      type: file
+      description: |
+        All germline structural variants with their GRIPSS filter annotations, with index
+        Structure: [ val(meta), path(vcf), path(tbi) ]
+      pattern: "*.gripss.germline.vcf.gz"
+authors:
+  - "@imsarath"
+maintainers:
+  - "@imsarath"

--- a/subworkflows/local/call_svs/tests/main.nf.test
+++ b/subworkflows/local/call_svs/tests/main.nf.test
@@ -1,0 +1,180 @@
+nextflow_workflow {
+
+    name "Test Subworkflow CALL_SVS"
+    script "../main.nf"
+    workflow "CALL_SVS"
+
+    tag "subworkflows"
+    tag "subworkflows_local"
+    tag "subworkflows/call_svs"
+    tag "gridss"
+    tag "gripss"
+    tag "untar"
+
+    setup {
+        run("UNTAR") {
+            script "../../../../modules/nf-core/untar/main.nf"
+            process {
+                """
+                input[0] = channel.of([
+                    [ id:'gridss_index' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/gridss_index.tar.gz', checkIfExists: true)
+                ])
+                """
+            }
+        }
+    }
+
+    test("paired tumor and normal samples") {
+
+        when {
+            workflow {
+                """
+                input[0] = channel.of(
+                    [
+                        [ id:'TUMOR', case_id:'TEST', sample_name:'TUMOR', sample_type:'tumor' ],
+                        file(params.pipelines_testdata_base_path + 'testdata/bam/TUMOR_dedup.bam', checkIfExists: true),
+                        file(params.pipelines_testdata_base_path + 'testdata/bam/TUMOR_dedup.bai', checkIfExists: true)
+                    ],
+                    [
+                        [ id:'NORMAL', case_id:'TEST', sample_name:'NORMAL', sample_type:'normal' ],
+                        file(params.pipelines_testdata_base_path + 'testdata/bam/NORMAL_dedup.bam', checkIfExists: true),
+                        file(params.pipelines_testdata_base_path + 'testdata/bam/NORMAL_dedup.bai', checkIfExists: true)
+                    ]
+                )
+                input[1] = channel.value([
+                    [ id:'genome' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.fasta', checkIfExists: true)
+                ])
+                input[2] = channel.value([
+                    [ id:'genome_fai' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.fasta.fai', checkIfExists: true)
+                ])
+                input[3] = UNTAR.out.untar.collect()
+                input[4] = channel.value([
+                    [ id:'genome_dict' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.dict', checkIfExists: true)
+                ])
+                input[5] = channel.value([
+                    [ id:'pon_breakends' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/gridss/sgl_pon.37.bed.gz', checkIfExists: true)
+                ])
+                input[6] = channel.value([
+                    [ id:'pon_breakpoints' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/gridss/sv_pon.37.bedpe.gz', checkIfExists: true)
+                ])
+                input[7] = channel.value([
+                    [ id:'known_fusions' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/gridss/known_fusions.37.bedpe', checkIfExists: true)
+                ])
+                input[8] = channel.value([
+                    [ id:'repeatmasker_annotations' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/gridss/repeat_mask_data.37.fa.gz', checkIfExists: true)
+                ])
+                input[9] = channel.value([
+                    [ id:'targets_bed' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/targets/test_panel.targets.slopped20.bed', checkIfExists: true)
+                ])
+                input[10] = channel.value([
+                    [ id:'gridss_config' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/gridss/gridss.properties', checkIfExists: true)
+                ])
+                input[11] = '37'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    // GRIDSS and GRIPSS write the tool version and the full command line into
+                    // the VCF header, so only the variant records are hashed
+                    workflow.out.gridss_vcf.collect { meta, vcf -> [meta, path(vcf).vcf.variantsMD5] },
+                    workflow.out.gripss_somatic_filtered_vcf.collect { meta, vcf, tbi -> [meta, path(vcf).vcf.variantsMD5, file(tbi).name] },
+                    workflow.out.gripss_somatic_unfiltered_vcf.collect { meta, vcf, tbi -> [meta, path(vcf).vcf.variantsMD5, file(tbi).name] },
+                    workflow.out.gripss_germline_filtered_vcf.collect { meta, vcf, tbi -> [meta, path(vcf).vcf.variantsMD5, file(tbi).name] },
+                    workflow.out.gripss_germline_unfiltered_vcf.collect { meta, vcf, tbi -> [meta, path(vcf).vcf.variantsMD5, file(tbi).name] }
+                ).match() }
+            )
+        }
+    }
+
+    test("paired tumor and normal samples - stub") {
+
+        options "-stub"
+
+        when {
+            workflow {
+                """
+                input[0] = channel.of(
+                    [
+                        [ id:'TUMOR', case_id:'TEST', sample_name:'TUMOR', sample_type:'tumor' ],
+                        file(params.pipelines_testdata_base_path + 'testdata/bam/TUMOR_dedup.bam', checkIfExists: true),
+                        file(params.pipelines_testdata_base_path + 'testdata/bam/TUMOR_dedup.bai', checkIfExists: true)
+                    ],
+                    [
+                        [ id:'NORMAL', case_id:'TEST', sample_name:'NORMAL', sample_type:'normal' ],
+                        file(params.pipelines_testdata_base_path + 'testdata/bam/NORMAL_dedup.bam', checkIfExists: true),
+                        file(params.pipelines_testdata_base_path + 'testdata/bam/NORMAL_dedup.bai', checkIfExists: true)
+                    ]
+                )
+                input[1] = channel.value([
+                    [ id:'genome' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.fasta', checkIfExists: true)
+                ])
+                input[2] = channel.value([
+                    [ id:'genome_fai' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.fasta.fai', checkIfExists: true)
+                ])
+                input[3] = UNTAR.out.untar.collect()
+                input[4] = channel.value([
+                    [ id:'genome_dict' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.dict', checkIfExists: true)
+                ])
+                input[5] = channel.value([
+                    [ id:'pon_breakends' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/gridss/sgl_pon.37.bed.gz', checkIfExists: true)
+                ])
+                input[6] = channel.value([
+                    [ id:'pon_breakpoints' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/gridss/sv_pon.37.bedpe.gz', checkIfExists: true)
+                ])
+                input[7] = channel.value([
+                    [ id:'known_fusions' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/gridss/known_fusions.37.bedpe', checkIfExists: true)
+                ])
+                input[8] = channel.value([
+                    [ id:'repeatmasker_annotations' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/gridss/repeat_mask_data.37.fa.gz', checkIfExists: true)
+                ])
+                input[9] = channel.value([
+                    [ id:'targets_bed' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/targets/test_panel.targets.slopped20.bed', checkIfExists: true)
+                ])
+                input[10] = channel.value([
+                    [ id:'gridss_config' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/gridss/gridss.properties', checkIfExists: true)
+                ])
+                input[11] = '37'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                // the empty `.vcf.gz` written by the GRIDSS and GRIPSS stubs cannot be
+                // decompressed and is serialised as an absolute work path, so only the
+                // file names are asserted
+                { assert snapshot(
+                    workflow.out.gridss_vcf.collect { meta, vcf -> [meta, file(vcf).name] },
+                    workflow.out.gripss_somatic_filtered_vcf.collect { meta, vcf, tbi -> [meta, file(vcf).name, file(tbi).name] },
+                    workflow.out.gripss_somatic_unfiltered_vcf.collect { meta, vcf, tbi -> [meta, file(vcf).name, file(tbi).name] },
+                    workflow.out.gripss_germline_filtered_vcf.collect { meta, vcf, tbi -> [meta, file(vcf).name, file(tbi).name] },
+                    workflow.out.gripss_germline_unfiltered_vcf.collect { meta, vcf, tbi -> [meta, file(vcf).name, file(tbi).name] }
+                ).match() }
+            )
+        }
+    }
+}

--- a/subworkflows/local/call_svs/tests/main.nf.test
+++ b/subworkflows/local/call_svs/tests/main.nf.test
@@ -91,10 +91,10 @@ nextflow_workflow {
                     // GRIDSS and GRIPSS write the tool version and the full command line into
                     // the VCF header, so only the variant records are hashed
                     workflow.out.gridss_vcf.collect { meta, vcf -> [meta, path(vcf).vcf.variantsMD5] },
-                    workflow.out.gripss_somatic_filtered_vcf.collect { meta, vcf, tbi -> [meta, path(vcf).vcf.variantsMD5, file(tbi).name] },
-                    workflow.out.gripss_somatic_unfiltered_vcf.collect { meta, vcf, tbi -> [meta, path(vcf).vcf.variantsMD5, file(tbi).name] },
-                    workflow.out.gripss_germline_filtered_vcf.collect { meta, vcf, tbi -> [meta, path(vcf).vcf.variantsMD5, file(tbi).name] },
-                    workflow.out.gripss_germline_unfiltered_vcf.collect { meta, vcf, tbi -> [meta, path(vcf).vcf.variantsMD5, file(tbi).name] }
+                    workflow.out.gripss_somatic_filtered_vcf.collect { meta, vcf, tbi -> [meta, "${file(vcf).name}:${path(vcf).vcf.variantsMD5}", file(tbi).name] },
+                    workflow.out.gripss_somatic_unfiltered_vcf.collect { meta, vcf, tbi -> [meta, "${file(vcf).name}:${path(vcf).vcf.variantsMD5}", file(tbi).name] },
+                    workflow.out.gripss_germline_filtered_vcf.collect { meta, vcf, tbi -> [meta, "${file(vcf).name}:${path(vcf).vcf.variantsMD5}", file(tbi).name] },
+                    workflow.out.gripss_germline_unfiltered_vcf.collect { meta, vcf, tbi -> [meta, "${file(vcf).name}:${path(vcf).vcf.variantsMD5}", file(tbi).name] }
                 ).match() }
             )
         }

--- a/subworkflows/local/call_svs/tests/main.nf.test.snap
+++ b/subworkflows/local/call_svs/tests/main.nf.test.snap
@@ -81,7 +81,7 @@
                         "normal_id": "NORMAL",
                         "tumor_id": "TUMOR"
                     },
-                    "d41d8cd98f00b204e9800998ecf8427e",
+                    "TUMOR.gripss.filtered.somatic.vcf.gz:d41d8cd98f00b204e9800998ecf8427e",
                     "TUMOR.gripss.filtered.somatic.vcf.gz.tbi"
                 ]
             ],
@@ -92,7 +92,7 @@
                         "normal_id": "NORMAL",
                         "tumor_id": "TUMOR"
                     },
-                    "d41d8cd98f00b204e9800998ecf8427e",
+                    "TUMOR.gripss.somatic.vcf.gz:d41d8cd98f00b204e9800998ecf8427e",
                     "TUMOR.gripss.somatic.vcf.gz.tbi"
                 ]
             ],
@@ -103,7 +103,7 @@
                         "normal_id": "NORMAL",
                         "tumor_id": "TUMOR"
                     },
-                    "d41d8cd98f00b204e9800998ecf8427e",
+                    "TUMOR.gripss.filtered.germline.vcf.gz:d41d8cd98f00b204e9800998ecf8427e",
                     "TUMOR.gripss.filtered.germline.vcf.gz.tbi"
                 ]
             ],
@@ -114,12 +114,12 @@
                         "normal_id": "NORMAL",
                         "tumor_id": "TUMOR"
                     },
-                    "d41d8cd98f00b204e9800998ecf8427e",
+                    "TUMOR.gripss.germline.vcf.gz:d41d8cd98f00b204e9800998ecf8427e",
                     "TUMOR.gripss.germline.vcf.gz.tbi"
                 ]
             ]
         ],
-        "timestamp": "2026-08-10T14:31:54.751853163",
+        "timestamp": "2026-08-13T14:50:27.587352",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "26.04.6"

--- a/subworkflows/local/call_svs/tests/main.nf.test.snap
+++ b/subworkflows/local/call_svs/tests/main.nf.test.snap
@@ -1,0 +1,128 @@
+{
+    "paired tumor and normal samples - stub": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "normal_id": "NORMAL",
+                        "tumor_id": "TUMOR"
+                    },
+                    "TEST.sv.gridss.vcf.gz"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "normal_id": "NORMAL",
+                        "tumor_id": "TUMOR"
+                    },
+                    "TUMOR.gripss.filtered.somatic.vcf.gz",
+                    "TUMOR.gripss.filtered.somatic.vcf.gz.tbi"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "normal_id": "NORMAL",
+                        "tumor_id": "TUMOR"
+                    },
+                    "TUMOR.gripss.somatic.vcf.gz",
+                    "TUMOR.gripss.somatic.vcf.gz.tbi"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "normal_id": "NORMAL",
+                        "tumor_id": "TUMOR"
+                    },
+                    "NORMAL.gripss.filtered.germline.vcf.gz",
+                    "NORMAL.gripss.filtered.germline.vcf.gz.tbi"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "normal_id": "NORMAL",
+                        "tumor_id": "TUMOR"
+                    },
+                    "NORMAL.gripss.germline.vcf.gz",
+                    "NORMAL.gripss.germline.vcf.gz.tbi"
+                ]
+            ]
+        ],
+        "timestamp": "2026-08-10T14:32:14.993362626",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "26.04.6"
+        }
+    },
+    "paired tumor and normal samples": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "normal_id": "NORMAL",
+                        "tumor_id": "TUMOR"
+                    },
+                    "d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "normal_id": "NORMAL",
+                        "tumor_id": "TUMOR"
+                    },
+                    "d41d8cd98f00b204e9800998ecf8427e",
+                    "TUMOR.gripss.filtered.somatic.vcf.gz.tbi"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "normal_id": "NORMAL",
+                        "tumor_id": "TUMOR"
+                    },
+                    "d41d8cd98f00b204e9800998ecf8427e",
+                    "TUMOR.gripss.somatic.vcf.gz.tbi"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "normal_id": "NORMAL",
+                        "tumor_id": "TUMOR"
+                    },
+                    "d41d8cd98f00b204e9800998ecf8427e",
+                    "TUMOR.gripss.filtered.germline.vcf.gz.tbi"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "normal_id": "NORMAL",
+                        "tumor_id": "TUMOR"
+                    },
+                    "d41d8cd98f00b204e9800998ecf8427e",
+                    "TUMOR.gripss.germline.vcf.gz.tbi"
+                ]
+            ]
+        ],
+        "timestamp": "2026-08-10T14:31:54.751853163",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "26.04.6"
+        }
+    }
+}


### PR DESCRIPTION
### Added

- nf-test for the `CALL_SVS` subworkflow covering a paired tumor/normal case and a stub case.
- `meta.yml` describing the subworkflow inputs and outputs.

Closes #68