### PR TITLE
test: add nf-test for call_somatic_snvs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Initial release of genomic-medicine-sweden/autoseq, created with the [nf-core](h
 - [ #50 ](https://github.com/genomic-medicine-sweden/autoseq/pull/50) Added `PREPARE_REFERENCES` subworkflow to build the BWA-MEM2 index and untar the VEP cache, GRIDSS index and HMF ensembl_data references, with nf-test coverage.
 - [ #55 ](https://github.com/genomic-medicine-sweden/autoseq/pull/55) Enabled an end-to-end `-profile test` run of the paired tumor/normal workflow on real GRCh37 test data.
 - [ #71 ](https://github.com/genomic-medicine-sweden/autoseq/pull/71) Added a `test_umi` profile and pipeline-level nf-test covering the UMI alignment branch on paired tumor/normal test data.
+- [ #90 ](https://github.com/genomic-medicine-sweden/autoseq/pull/90) Added nf-test and `meta.yml` for the `CALL_SOMATIC_SNVS` subworkflow covering a paired tumor/normal case and a stub case.
 
 ### `Changed`
 

--- a/subworkflows/local/call_somatic_snvs/meta.yml
+++ b/subworkflows/local/call_somatic_snvs/meta.yml
@@ -1,0 +1,201 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+name: "call_somatic_snvs"
+description: Call somatic SNVs and indels from a paired tumor/normal case with GATK Mutect2 and SAGE, merge the two call sets and annotate them with Ensembl VEP
+keywords:
+  - somatic
+  - snv
+  - mutect2
+  - sage
+  - annotation
+  - vep
+components:
+  - bam_tumor_normal_somatic_variant_calling_gatk
+  - vt/decompose
+  - vt/normalize
+  - tabix/tabix
+  - bcftools/filter
+  - sage/somatic
+  - vcfmerge
+  - ensemblvep/vep
+input:
+  - ch_input:
+      type: file
+      description: |
+        Aligned, deduplicated tumor and normal BAM files with their indices and the
+        intervals to restrict calling to. The tumor sample must come first in both lists.
+        Structure: [ val(meta), [ path(tumor_bam), path(normal_bam) ], [ path(tumor_bai), path(normal_bai) ], path(intervals) ]
+      pattern: "*.bam"
+  - ch_fasta:
+      type: file
+      description: |
+        Reference genome FASTA
+        Structure: [ val(meta), path(fasta) ]
+      pattern: "*.{fa,fasta}"
+  - ch_fai:
+      type: file
+      description: |
+        Index of the reference genome FASTA
+        Structure: [ val(meta), path(fai) ]
+      pattern: "*.fai"
+  - ch_dict:
+      type: file
+      description: |
+        Sequence dictionary of the reference genome
+        Structure: [ val(meta), path(dict) ]
+      pattern: "*.dict"
+  - ch_germline_resource:
+      type: file
+      description: |
+        Population allele frequency resource used by Mutect2
+        Structure: [ path(vcf) ]
+      pattern: "*.vcf.gz"
+  - ch_germline_resource_tbi:
+      type: file
+      description: |
+        Index of the germline resource
+        Structure: [ path(tbi) ]
+      pattern: "*.vcf.gz.tbi"
+  - ch_panel_of_normals:
+      type: file
+      description: |
+        Panel of normals used by Mutect2
+        Structure: [ path(vcf) ]
+      pattern: "*.vcf.gz"
+  - ch_panel_of_normals_tbi:
+      type: file
+      description: |
+        Index of the panel of normals
+        Structure: [ path(tbi) ]
+      pattern: "*.vcf.gz.tbi"
+  - ch_interval_file:
+      type: file
+      description: |
+        Interval list used for the pileup summaries
+        Structure: [ path(intervals) ]
+      pattern: "*.interval_list"
+  - ch_sage_known_hotspots_somatic:
+      type: file
+      description: |
+        Known somatic hotspots rescued by SAGE
+        Structure: [ val(meta), path(vcf) ]
+      pattern: "*.vcf.gz"
+  - ch_sage_highconf_regions:
+      type: file
+      description: |
+        High confidence regions used by SAGE
+        Structure: [ val(meta), path(bed) ]
+      pattern: "*.bed.gz"
+  - ch_sage_pon:
+      type: file
+      description: |
+        SAGE panel of normals
+        Structure: [ val(meta), path(tsv) ]
+      pattern: "*.tsv.gz"
+  - ch_ensembl_data_resources:
+      type: directory
+      description: |
+        HMF Ensembl data resource directory used by SAGE
+        Structure: [ val(meta), path(dir) ]
+  - ch_ensembl_vep_cache:
+      type: directory
+      description: |
+        Ensembl VEP cache directory
+        Structure: [ val(meta), path(cache) ]
+  - genome_version:
+      type: string
+      description: Numeric reference genome version passed to SAGE ('37' or '38')
+output:
+  - contamination_table:
+      type: file
+      description: |
+        Contamination estimate of the tumor sample
+        Structure: [ val(meta), path(table) ]
+      pattern: "*.contamination.table"
+  - mutect2_stats:
+      type: file
+      description: |
+        Filtering statistics of the Mutect2 call set
+        Structure: [ val(meta), path(stats) ]
+      pattern: "*.filteringStats.tsv"
+  - mutect2_tbi:
+      type: file
+      description: |
+        Index of the filtered Mutect2 VCF
+        Structure: [ val(meta), path(tbi) ]
+      pattern: "*.vcf.gz.tbi"
+  - mutect2_vcf:
+      type: file
+      description: |
+        Filtered Mutect2 call set
+        Structure: [ val(meta), path(vcf) ]
+      pattern: "*.vcf.gz"
+  - pileup_table_normal:
+      type: file
+      description: |
+        Pileup summaries of the normal sample
+        Structure: [ val(meta), path(table) ]
+      pattern: "*.pileups.table"
+  - pileup_table_tumor:
+      type: file
+      description: |
+        Pileup summaries of the tumor sample
+        Structure: [ val(meta), path(table) ]
+      pattern: "*.pileups.table"
+  - mutect2_unfiltered_vcf:
+      type: file
+      description: |
+        Raw Mutect2 call set before filtering
+        Structure: [ val(meta), path(vcf) ]
+      pattern: "*.vcf.gz"
+  - mutect2_unfiltered_tbi:
+      type: file
+      description: |
+        Index of the raw Mutect2 VCF
+        Structure: [ val(meta), path(tbi) ]
+      pattern: "*.vcf.gz.tbi"
+  - sage_vcf:
+      type: file
+      description: |
+        SAGE call set
+        Structure: [ val(meta), path(vcf) ]
+      pattern: "*.vcf.gz"
+  - sage_tbi:
+      type: file
+      description: |
+        Index of the SAGE VCF
+        Structure: [ val(meta), path(tbi) ]
+      pattern: "*.vcf.gz.tbi"
+  - somatic_vcf:
+      type: file
+      description: |
+        Merged Mutect2 and SAGE call set
+        Structure: [ val(meta), path(vcf) ]
+      pattern: "*.vcf.gz"
+  - somatic_tbi:
+      type: file
+      description: |
+        Index of the merged VCF
+        Structure: [ val(meta), path(tbi) ]
+      pattern: "*.vcf.gz.tbi"
+  - vep_vcf:
+      type: file
+      description: |
+        Merged call set annotated with Ensembl VEP
+        Structure: [ val(meta), path(vcf) ]
+      pattern: "*.vcf.gz"
+  - vep_tbi:
+      type: file
+      description: |
+        Index of the VEP annotated VCF
+        Structure: [ val(meta), path(tbi) ]
+      pattern: "*.vcf.gz.tbi"
+  - versions:
+      type: file
+      description: |
+        Files containing software versions
+        Structure: [ path(versions.yml) ]
+      pattern: "versions.yml"
+authors:
+  - "@imsarath"
+maintainers:
+  - "@imsarath"

--- a/subworkflows/local/call_somatic_snvs/tests/main.nf.test
+++ b/subworkflows/local/call_somatic_snvs/tests/main.nf.test
@@ -104,11 +104,11 @@ nextflow_workflow {
                 { assert snapshot(
                     // GATK, SAGE, bcftools and VEP all write the tool version and the full
                     // command line into the VCF header, so only the variant records are hashed
-                    workflow.out.mutect2_unfiltered_vcf.collect { meta, vcf -> [meta, path(vcf).vcf.variantsMD5] },
-                    workflow.out.mutect2_vcf.collect { meta, vcf -> [meta, path(vcf).vcf.variantsMD5] },
-                    workflow.out.sage_vcf.collect { meta, vcf -> [meta, path(vcf).vcf.variantsMD5] },
-                    workflow.out.somatic_vcf.collect { meta, vcf -> [meta, path(vcf).vcf.variantsMD5] },
-                    workflow.out.vep_vcf.collect { meta, vcf -> [meta, path(vcf).vcf.variantsMD5] },
+                    workflow.out.mutect2_unfiltered_vcf.collect { meta, vcf -> [meta, "${file(vcf).name}:md5,${path(vcf).vcf.variantsMD5}"] },
+                    workflow.out.mutect2_vcf.collect { meta, vcf -> [meta, "${file(vcf).name}:md5,${path(vcf).vcf.variantsMD5}"] },
+                    workflow.out.sage_vcf.collect { meta, vcf -> [meta, "${file(vcf).name}:md5,${path(vcf).vcf.variantsMD5}"] },
+                    workflow.out.somatic_vcf.collect { meta, vcf -> [meta, "${file(vcf).name}:md5,${path(vcf).vcf.variantsMD5}"] },
+                    workflow.out.vep_vcf.collect { meta, vcf -> [meta, "${file(vcf).name}:md5,${path(vcf).vcf.variantsMD5}"] },
                     workflow.out.mutect2_unfiltered_tbi.collect { meta, tbi -> [meta, file(tbi).name] },
                     workflow.out.mutect2_tbi.collect { meta, tbi -> [meta, file(tbi).name] },
                     workflow.out.sage_tbi.collect { meta, tbi -> [meta, file(tbi).name] },

--- a/subworkflows/local/call_somatic_snvs/tests/main.nf.test
+++ b/subworkflows/local/call_somatic_snvs/tests/main.nf.test
@@ -99,16 +99,18 @@ nextflow_workflow {
         }
 
         then {
+            def vcfVariantsMd5 = { ch -> ch.collect { meta, vcf -> [meta, "${file(vcf).name}:md5,${path(vcf).vcf.variantsMD5}"] } }
+
             assertAll(
                 { assert workflow.success },
                 { assert snapshot(
                     // GATK, SAGE, bcftools and VEP all write the tool version and the full
                     // command line into the VCF header, so only the variant records are hashed
-                    workflow.out.mutect2_unfiltered_vcf.collect { meta, vcf -> [meta, "${file(vcf).name}:md5,${path(vcf).vcf.variantsMD5}"] },
-                    workflow.out.mutect2_vcf.collect { meta, vcf -> [meta, "${file(vcf).name}:md5,${path(vcf).vcf.variantsMD5}"] },
-                    workflow.out.sage_vcf.collect { meta, vcf -> [meta, "${file(vcf).name}:md5,${path(vcf).vcf.variantsMD5}"] },
-                    workflow.out.somatic_vcf.collect { meta, vcf -> [meta, "${file(vcf).name}:md5,${path(vcf).vcf.variantsMD5}"] },
-                    workflow.out.vep_vcf.collect { meta, vcf -> [meta, "${file(vcf).name}:md5,${path(vcf).vcf.variantsMD5}"] },
+                    vcfVariantsMd5(workflow.out.mutect2_unfiltered_vcf),
+                    vcfVariantsMd5(workflow.out.mutect2_vcf),
+                    vcfVariantsMd5(workflow.out.sage_vcf),
+                    vcfVariantsMd5(workflow.out.somatic_vcf),
+                    vcfVariantsMd5(workflow.out.vep_vcf),
                     workflow.out.mutect2_unfiltered_tbi.collect { meta, tbi -> [meta, file(tbi).name] },
                     workflow.out.mutect2_tbi.collect { meta, tbi -> [meta, file(tbi).name] },
                     workflow.out.sage_tbi.collect { meta, tbi -> [meta, file(tbi).name] },

--- a/subworkflows/local/call_somatic_snvs/tests/main.nf.test
+++ b/subworkflows/local/call_somatic_snvs/tests/main.nf.test
@@ -1,0 +1,208 @@
+nextflow_workflow {
+
+    name "Test Subworkflow CALL_SOMATIC_SNVS"
+    script "../main.nf"
+    workflow "CALL_SOMATIC_SNVS"
+    config "./nextflow.config"
+
+    tag "subworkflows"
+    tag "subworkflows_local"
+    tag "subworkflows/call_somatic_snvs"
+    tag "gatk4"
+    tag "gatk4/mutect2"
+    tag "sage"
+    tag "vt"
+    tag "bcftools"
+    tag "bcftools/filter"
+    tag "vcfmerge"
+    tag "ensemblvep"
+    tag "ensemblvep/vep"
+    tag "untar"
+
+    setup {
+        run("UNTAR", alias: "UNTAR_VEP_CACHE") {
+            script "../../../../modules/nf-core/untar/main.nf"
+            process {
+                """
+                input[0] = channel.of([
+                    [ id:'vep_cache' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/vep.tar.gz', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        run("UNTAR", alias: "UNTAR_ENSEMBL_DATA") {
+            script "../../../../modules/nf-core/untar/main.nf"
+            process {
+                """
+                input[0] = channel.of([
+                    [ id:'ensembl_data' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/ensembl_data.tar.gz', checkIfExists: true)
+                ])
+                """
+            }
+        }
+    }
+
+    test("paired tumor and normal samples") {
+
+        when {
+            workflow {
+                """
+                input[0] = channel.of([
+                    [ id:'TEST', case_id:'TEST', tumor_id:'TUMOR', normal_id:'NORMAL', tumor_sample:'TUMOR', normal_sample:'NORMAL' ],
+                    [
+                        file(params.pipelines_testdata_base_path + 'testdata/bam/TUMOR_dedup.bam', checkIfExists: true),
+                        file(params.pipelines_testdata_base_path + 'testdata/bam/NORMAL_dedup.bam', checkIfExists: true)
+                    ],
+                    [
+                        file(params.pipelines_testdata_base_path + 'testdata/bam/TUMOR_dedup.bai', checkIfExists: true),
+                        file(params.pipelines_testdata_base_path + 'testdata/bam/NORMAL_dedup.bai', checkIfExists: true)
+                    ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/targets/test_panel.targets.slopped20.interval_list', checkIfExists: true)
+                ])
+                input[1] = channel.value([
+                    [ id:'genome' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.fasta', checkIfExists: true)
+                ])
+                input[2] = channel.value([
+                    [ id:'genome_fai' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.fasta.fai', checkIfExists: true)
+                ])
+                input[3] = channel.value([
+                    [ id:'genome_dict' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.dict', checkIfExists: true)
+                ])
+                input[4] = channel.value(file(params.pipelines_testdata_base_path + 'reference/GRCh37/annotations/af-only-gnomad.raw.sites.vcf.gz', checkIfExists: true))
+                input[5] = channel.value(file(params.pipelines_testdata_base_path + 'reference/GRCh37/annotations/af-only-gnomad.raw.sites.vcf.gz.tbi', checkIfExists: true))
+                input[6] = []
+                input[7] = []
+                input[8] = channel.value(file(params.pipelines_testdata_base_path + 'reference/GRCh37/targets/test_panel.targets.slopped20.interval_list', checkIfExists: true))
+                input[9] = channel.value([
+                    [ id:'sage_known_hotspots_somatic' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/hmfdata/KnownHotspots.somatic.37.vcf.gz', checkIfExists: true)
+                ])
+                input[10] = channel.value([
+                    [ id:'sage_highconf_regions' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/hmfdata/NA12878_GIAB_highconf_IllFB-IllGATKHC-CG-Ion-Solid_ALLCHROM_v3.2.2_highconf.bed.gz', checkIfExists: true)
+                ])
+                input[11] = channel.value([
+                    [ id:'sage_pon' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/hmfdata/SageGermlinePon.1000x.37.tsv.gz', checkIfExists: true)
+                ])
+                input[12] = UNTAR_ENSEMBL_DATA.out.untar.collect()
+                input[13] = UNTAR_VEP_CACHE.out.untar.collect()
+                input[14] = '37'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    // GATK, SAGE, bcftools and VEP all write the tool version and the full
+                    // command line into the VCF header, so only the variant records are hashed
+                    workflow.out.mutect2_unfiltered_vcf.collect { meta, vcf -> [meta, path(vcf).vcf.variantsMD5] },
+                    workflow.out.mutect2_vcf.collect { meta, vcf -> [meta, path(vcf).vcf.variantsMD5] },
+                    workflow.out.sage_vcf.collect { meta, vcf -> [meta, path(vcf).vcf.variantsMD5] },
+                    workflow.out.somatic_vcf.collect { meta, vcf -> [meta, path(vcf).vcf.variantsMD5] },
+                    workflow.out.vep_vcf.collect { meta, vcf -> [meta, path(vcf).vcf.variantsMD5] },
+                    workflow.out.mutect2_unfiltered_tbi.collect { meta, tbi -> [meta, file(tbi).name] },
+                    workflow.out.mutect2_tbi.collect { meta, tbi -> [meta, file(tbi).name] },
+                    workflow.out.sage_tbi.collect { meta, tbi -> [meta, file(tbi).name] },
+                    workflow.out.somatic_tbi.collect { meta, tbi -> [meta, file(tbi).name] },
+                    workflow.out.vep_tbi.collect { meta, tbi -> [meta, file(tbi).name] },
+                    workflow.out.contamination_table,
+                    workflow.out.pileup_table_tumor,
+                    workflow.out.pileup_table_normal,
+                    workflow.out.mutect2_stats,
+                    workflow.out.versions
+                ).match() }
+            )
+        }
+    }
+
+    test("paired tumor and normal samples - stub") {
+
+        options "-stub"
+
+        when {
+            workflow {
+                """
+                input[0] = channel.of([
+                    [ id:'TEST', case_id:'TEST', tumor_id:'TUMOR', normal_id:'NORMAL', tumor_sample:'TUMOR', normal_sample:'NORMAL' ],
+                    [
+                        file(params.pipelines_testdata_base_path + 'testdata/bam/TUMOR_dedup.bam', checkIfExists: true),
+                        file(params.pipelines_testdata_base_path + 'testdata/bam/NORMAL_dedup.bam', checkIfExists: true)
+                    ],
+                    [
+                        file(params.pipelines_testdata_base_path + 'testdata/bam/TUMOR_dedup.bai', checkIfExists: true),
+                        file(params.pipelines_testdata_base_path + 'testdata/bam/NORMAL_dedup.bai', checkIfExists: true)
+                    ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/targets/test_panel.targets.slopped20.interval_list', checkIfExists: true)
+                ])
+                input[1] = channel.value([
+                    [ id:'genome' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.fasta', checkIfExists: true)
+                ])
+                input[2] = channel.value([
+                    [ id:'genome_fai' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.fasta.fai', checkIfExists: true)
+                ])
+                input[3] = channel.value([
+                    [ id:'genome_dict' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.dict', checkIfExists: true)
+                ])
+                input[4] = channel.value(file(params.pipelines_testdata_base_path + 'reference/GRCh37/annotations/af-only-gnomad.raw.sites.vcf.gz', checkIfExists: true))
+                input[5] = channel.value(file(params.pipelines_testdata_base_path + 'reference/GRCh37/annotations/af-only-gnomad.raw.sites.vcf.gz.tbi', checkIfExists: true))
+                input[6] = []
+                input[7] = []
+                input[8] = channel.value(file(params.pipelines_testdata_base_path + 'reference/GRCh37/targets/test_panel.targets.slopped20.interval_list', checkIfExists: true))
+                input[9] = channel.value([
+                    [ id:'sage_known_hotspots_somatic' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/hmfdata/KnownHotspots.somatic.37.vcf.gz', checkIfExists: true)
+                ])
+                input[10] = channel.value([
+                    [ id:'sage_highconf_regions' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/hmfdata/NA12878_GIAB_highconf_IllFB-IllGATKHC-CG-Ion-Solid_ALLCHROM_v3.2.2_highconf.bed.gz', checkIfExists: true)
+                ])
+                input[11] = channel.value([
+                    [ id:'sage_pon' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/hmfdata/SageGermlinePon.1000x.37.tsv.gz', checkIfExists: true)
+                ])
+                input[12] = UNTAR_ENSEMBL_DATA.out.untar.collect()
+                input[13] = UNTAR_VEP_CACHE.out.untar.collect()
+                input[14] = '37'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                // the empty `.vcf.gz` written by the SAGE and vcfmerge stubs cannot be
+                // decompressed and is serialised as an absolute work path, so only the
+                // file names are asserted
+                { assert snapshot(
+                    workflow.out.mutect2_unfiltered_vcf.collect { meta, vcf -> [meta, file(vcf).name] },
+                    workflow.out.mutect2_vcf.collect { meta, vcf -> [meta, file(vcf).name] },
+                    workflow.out.sage_vcf.collect { meta, vcf -> [meta, file(vcf).name] },
+                    workflow.out.somatic_vcf.collect { meta, vcf -> [meta, file(vcf).name] },
+                    workflow.out.vep_vcf.collect { meta, vcf -> [meta, file(vcf).name] },
+                    workflow.out.mutect2_unfiltered_tbi.collect { meta, tbi -> [meta, file(tbi).name] },
+                    workflow.out.mutect2_tbi.collect { meta, tbi -> [meta, file(tbi).name] },
+                    workflow.out.sage_tbi.collect { meta, tbi -> [meta, file(tbi).name] },
+                    workflow.out.somatic_tbi.collect { meta, tbi -> [meta, file(tbi).name] },
+                    workflow.out.vep_tbi.collect { meta, tbi -> [meta, file(tbi).name] },
+                    workflow.out.contamination_table,
+                    workflow.out.pileup_table_tumor,
+                    workflow.out.pileup_table_normal,
+                    workflow.out.mutect2_stats,
+                    workflow.out.versions
+                ).match() }
+            )
+        }
+    }
+}

--- a/subworkflows/local/call_somatic_snvs/tests/main.nf.test.snap
+++ b/subworkflows/local/call_somatic_snvs/tests/main.nf.test.snap
@@ -217,7 +217,7 @@
                         "tumor_sample": "TUMOR",
                         "normal_sample": "NORMAL"
                     },
-                    "79a9e8d4fa57fabf3fd82051c03488c7"
+                    "TEST.vcf.gz:md5,79a9e8d4fa57fabf3fd82051c03488c7"
                 ]
             ],
             [
@@ -230,7 +230,7 @@
                         "tumor_sample": "TUMOR",
                         "normal_sample": "NORMAL"
                     },
-                    "673d3ee2ad91e129bf8137aeeba1cd04"
+                    "TUMOR_NORMAL_mutect2_filtered.vcf.gz:md5,673d3ee2ad91e129bf8137aeeba1cd04"
                 ]
             ],
             [
@@ -243,7 +243,7 @@
                         "tumor_sample": "TUMOR",
                         "normal_sample": "NORMAL"
                     },
-                    "b2181f9945a8d84ed2a8e40b94a9d675"
+                    "TUMOR.sage.somatic.vcf.gz:md5,b2181f9945a8d84ed2a8e40b94a9d675"
                 ]
             ],
             [
@@ -256,7 +256,7 @@
                         "tumor_sample": "TUMOR",
                         "normal_sample": "NORMAL"
                     },
-                    "15d5903edd6e671a148453861f88552f"
+                    "TUMOR_NORMAL-all.somatic.vcf.gz:md5,15d5903edd6e671a148453861f88552f"
                 ]
             ],
             [
@@ -269,7 +269,7 @@
                         "tumor_sample": "TUMOR",
                         "normal_sample": "NORMAL"
                     },
-                    "d41d8cd98f00b204e9800998ecf8427e"
+                    "TUMOR_NORMAL-all.somatic.vep.vcf.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ]
             ],
             [
@@ -405,7 +405,7 @@
                 "versions.yml:md5,e9144de1ba616dfa846e8fe234bce2e1"
             ]
         ],
-        "timestamp": "2026-08-10T14:41:06.837812489",
+        "timestamp": "2026-08-13T15:59:20.106934312",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "26.04.6"

--- a/subworkflows/local/call_somatic_snvs/tests/main.nf.test.snap
+++ b/subworkflows/local/call_somatic_snvs/tests/main.nf.test.snap
@@ -256,7 +256,7 @@
                         "tumor_sample": "TUMOR",
                         "normal_sample": "NORMAL"
                     },
-                    "TUMOR_NORMAL-all.somatic.vcf.gz:md5,15d5903edd6e671a148453861f88552f"
+                    "TUMOR_NORMAL-all.somatic.vcf.gz:md5,c17d2b6276b5f7b40b2afb3f25f055b3"
                 ]
             ],
             [
@@ -405,7 +405,7 @@
                 "versions.yml:md5,e9144de1ba616dfa846e8fe234bce2e1"
             ]
         ],
-        "timestamp": "2026-08-13T15:59:20.106934312",
+        "timestamp": "2026-08-14T14:09:22.313097949",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "26.04.6"

--- a/subworkflows/local/call_somatic_snvs/tests/main.nf.test.snap
+++ b/subworkflows/local/call_somatic_snvs/tests/main.nf.test.snap
@@ -1,0 +1,414 @@
+{
+    "paired tumor and normal samples - stub": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "case_id": "TEST",
+                        "tumor_id": "TUMOR",
+                        "normal_id": "NORMAL",
+                        "tumor_sample": "TUMOR",
+                        "normal_sample": "NORMAL"
+                    },
+                    "TEST.vcf.gz"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "case_id": "TEST",
+                        "tumor_id": "TUMOR",
+                        "normal_id": "NORMAL",
+                        "tumor_sample": "TUMOR",
+                        "normal_sample": "NORMAL"
+                    },
+                    "TUMOR_NORMAL_mutect2_filtered.vcf.gz"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "case_id": "TEST",
+                        "tumor_id": "TUMOR",
+                        "normal_id": "NORMAL",
+                        "tumor_sample": "TUMOR",
+                        "normal_sample": "NORMAL"
+                    },
+                    "TUMOR.sage.somatic.vcf.gz"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "case_id": "TEST",
+                        "tumor_id": "TUMOR",
+                        "normal_id": "NORMAL",
+                        "tumor_sample": "TUMOR",
+                        "normal_sample": "NORMAL"
+                    },
+                    "TUMOR_NORMAL-all.somatic.vcf.gz"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "case_id": "TEST",
+                        "tumor_id": "TUMOR",
+                        "normal_id": "NORMAL",
+                        "tumor_sample": "TUMOR",
+                        "normal_sample": "NORMAL"
+                    },
+                    "TUMOR_NORMAL-all.somatic.vep.vcf.gz"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "case_id": "TEST",
+                        "tumor_id": "TUMOR",
+                        "normal_id": "NORMAL",
+                        "tumor_sample": "TUMOR",
+                        "normal_sample": "NORMAL"
+                    },
+                    "TEST.vcf.gz.tbi"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "case_id": "TEST",
+                        "tumor_id": "TUMOR",
+                        "normal_id": "NORMAL",
+                        "tumor_sample": "TUMOR",
+                        "normal_sample": "NORMAL"
+                    },
+                    "TUMOR_NORMAL_mutect2_filtered.vcf.gz.tbi"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "case_id": "TEST",
+                        "tumor_id": "TUMOR",
+                        "normal_id": "NORMAL",
+                        "tumor_sample": "TUMOR",
+                        "normal_sample": "NORMAL"
+                    },
+                    "TUMOR.sage.somatic.vcf.gz.tbi"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "case_id": "TEST",
+                        "tumor_id": "TUMOR",
+                        "normal_id": "NORMAL",
+                        "tumor_sample": "TUMOR",
+                        "normal_sample": "NORMAL"
+                    },
+                    "TUMOR_NORMAL-all.somatic.vcf.gz.tbi"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "case_id": "TEST",
+                        "tumor_id": "TUMOR",
+                        "normal_id": "NORMAL",
+                        "tumor_sample": "TUMOR",
+                        "normal_sample": "NORMAL"
+                    },
+                    "TUMOR_NORMAL-all.somatic.vep.vcf.gz.tbi"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "case_id": "TEST",
+                        "tumor_id": "TUMOR",
+                        "normal_id": "NORMAL",
+                        "tumor_sample": "TUMOR",
+                        "normal_sample": "NORMAL"
+                    },
+                    "TUMOR_NORMAL.contamination.table:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "case_id": "TEST",
+                        "tumor_id": "TUMOR",
+                        "normal_id": "NORMAL",
+                        "tumor_sample": "TUMOR",
+                        "normal_sample": "NORMAL"
+                    },
+                    "TEST_TUMOR.pileups.table:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "case_id": "TEST",
+                        "tumor_id": "TUMOR",
+                        "normal_id": "NORMAL",
+                        "tumor_sample": "TUMOR",
+                        "normal_sample": "NORMAL"
+                    },
+                    "TEST_NORMAL.pileups.table:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "case_id": "TEST",
+                        "tumor_id": "TUMOR",
+                        "normal_id": "NORMAL",
+                        "tumor_sample": "TUMOR",
+                        "normal_sample": "NORMAL"
+                    },
+                    "TUMOR_NORMAL_mutect2_filtered.vcf.gz.filteringStats.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                "versions.yml:md5,0eee4697c4e6354b97ad8dee726beac7",
+                "versions.yml:md5,200a49bb791cb91cdc7b98743846ded5",
+                "versions.yml:md5,326cdfa4370c5f01df917aa8241c15eb",
+                "versions.yml:md5,73fd69579fc8eafe575f6eb6b9f1dd7d",
+                "versions.yml:md5,770bc1ffe972799e73555b39bcfb7ed8",
+                "versions.yml:md5,8bcf6c9c31a7acfa29c74c5854c0591f",
+                "versions.yml:md5,9450fdae8ac9eed8d06b14402971d32b",
+                "versions.yml:md5,a658f41fc132c2773f220c7df665149b",
+                "versions.yml:md5,ae52273f9353ec9e68006dcbaa78287c",
+                "versions.yml:md5,ba3d0fb10abd7c7cf87331d07b7c80f9",
+                "versions.yml:md5,c49ac7b84e76c6642e942c5bdd7543bf",
+                "versions.yml:md5,e6bcface9c0377031854a66cf2932747",
+                "versions.yml:md5,e9144de1ba616dfa846e8fe234bce2e1"
+            ]
+        ],
+        "timestamp": "2026-08-10T14:47:04.751582424",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "26.04.6"
+        }
+    },
+    "paired tumor and normal samples": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "case_id": "TEST",
+                        "tumor_id": "TUMOR",
+                        "normal_id": "NORMAL",
+                        "tumor_sample": "TUMOR",
+                        "normal_sample": "NORMAL"
+                    },
+                    "79a9e8d4fa57fabf3fd82051c03488c7"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "case_id": "TEST",
+                        "tumor_id": "TUMOR",
+                        "normal_id": "NORMAL",
+                        "tumor_sample": "TUMOR",
+                        "normal_sample": "NORMAL"
+                    },
+                    "673d3ee2ad91e129bf8137aeeba1cd04"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "case_id": "TEST",
+                        "tumor_id": "TUMOR",
+                        "normal_id": "NORMAL",
+                        "tumor_sample": "TUMOR",
+                        "normal_sample": "NORMAL"
+                    },
+                    "b2181f9945a8d84ed2a8e40b94a9d675"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "case_id": "TEST",
+                        "tumor_id": "TUMOR",
+                        "normal_id": "NORMAL",
+                        "tumor_sample": "TUMOR",
+                        "normal_sample": "NORMAL"
+                    },
+                    "15d5903edd6e671a148453861f88552f"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "case_id": "TEST",
+                        "tumor_id": "TUMOR",
+                        "normal_id": "NORMAL",
+                        "tumor_sample": "TUMOR",
+                        "normal_sample": "NORMAL"
+                    },
+                    "d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "case_id": "TEST",
+                        "tumor_id": "TUMOR",
+                        "normal_id": "NORMAL",
+                        "tumor_sample": "TUMOR",
+                        "normal_sample": "NORMAL"
+                    },
+                    "TEST.vcf.gz.tbi"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "case_id": "TEST",
+                        "tumor_id": "TUMOR",
+                        "normal_id": "NORMAL",
+                        "tumor_sample": "TUMOR",
+                        "normal_sample": "NORMAL"
+                    },
+                    "TUMOR_NORMAL_mutect2_filtered.vcf.gz.tbi"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "case_id": "TEST",
+                        "tumor_id": "TUMOR",
+                        "normal_id": "NORMAL",
+                        "tumor_sample": "TUMOR",
+                        "normal_sample": "NORMAL"
+                    },
+                    "TUMOR.sage.somatic.vcf.gz.tbi"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "case_id": "TEST",
+                        "tumor_id": "TUMOR",
+                        "normal_id": "NORMAL",
+                        "tumor_sample": "TUMOR",
+                        "normal_sample": "NORMAL"
+                    },
+                    "TUMOR_NORMAL-all.somatic.vcf.gz.tbi"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "case_id": "TEST",
+                        "tumor_id": "TUMOR",
+                        "normal_id": "NORMAL",
+                        "tumor_sample": "TUMOR",
+                        "normal_sample": "NORMAL"
+                    },
+                    "TUMOR_NORMAL-all.somatic.vep.vcf.gz.tbi"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "case_id": "TEST",
+                        "tumor_id": "TUMOR",
+                        "normal_id": "NORMAL",
+                        "tumor_sample": "TUMOR",
+                        "normal_sample": "NORMAL"
+                    },
+                    "TUMOR_NORMAL.contamination.table:md5,a47aaa6933a5cfd12bcba937d74c0991"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "case_id": "TEST",
+                        "tumor_id": "TUMOR",
+                        "normal_id": "NORMAL",
+                        "tumor_sample": "TUMOR",
+                        "normal_sample": "NORMAL"
+                    },
+                    "TEST_TUMOR.pileups.table:md5,84bf40340a0433542ba926fad290c8eb"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "case_id": "TEST",
+                        "tumor_id": "TUMOR",
+                        "normal_id": "NORMAL",
+                        "tumor_sample": "TUMOR",
+                        "normal_sample": "NORMAL"
+                    },
+                    "TEST_NORMAL.pileups.table:md5,24b0f7ca933ea5839821f4041b79f9b2"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TEST",
+                        "case_id": "TEST",
+                        "tumor_id": "TUMOR",
+                        "normal_id": "NORMAL",
+                        "tumor_sample": "TUMOR",
+                        "normal_sample": "NORMAL"
+                    },
+                    "TUMOR_NORMAL_mutect2_filtered.vcf.gz.filteringStats.tsv:md5,eb61b96f3d2566a2c05aaf68f08a584d"
+                ]
+            ],
+            [
+                "versions.yml:md5,0eee4697c4e6354b97ad8dee726beac7",
+                "versions.yml:md5,200a49bb791cb91cdc7b98743846ded5",
+                "versions.yml:md5,326cdfa4370c5f01df917aa8241c15eb",
+                "versions.yml:md5,5936f081866e24879df93abeba8a493e",
+                "versions.yml:md5,770bc1ffe972799e73555b39bcfb7ed8",
+                "versions.yml:md5,8bcf6c9c31a7acfa29c74c5854c0591f",
+                "versions.yml:md5,9450fdae8ac9eed8d06b14402971d32b",
+                "versions.yml:md5,a658f41fc132c2773f220c7df665149b",
+                "versions.yml:md5,ae52273f9353ec9e68006dcbaa78287c",
+                "versions.yml:md5,ba3d0fb10abd7c7cf87331d07b7c80f9",
+                "versions.yml:md5,c49ac7b84e76c6642e942c5bdd7543bf",
+                "versions.yml:md5,e6bcface9c0377031854a66cf2932747",
+                "versions.yml:md5,e9144de1ba616dfa846e8fe234bce2e1"
+            ]
+        ],
+        "timestamp": "2026-08-10T14:41:06.837812489",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "26.04.6"
+        }
+    }
+}

--- a/subworkflows/local/call_somatic_snvs/tests/nextflow.config
+++ b/subworkflows/local/call_somatic_snvs/tests/nextflow.config
@@ -8,11 +8,12 @@ process {
     }
 
     withName: '.*CALL_SOMATIC_SNVS:PASSFILTER_FOR_MUTECT2' {
-        ext.args   = '--output-type z --write-index=tbi'
+        ext.args   = { " -i 'FILTER=\"PASS\"' --output-type z --write-index=tbi " }
         ext.prefix = { "${meta.tumor_id}_${meta.normal_id}_mutect2_pass_only" }
     }
 
     withName: '.*CALL_SOMATIC_SNVS:PASSFILTER_FOR_SAGE' {
+        ext.args   = { " -i 'FILTER=\"PASS\"' --output-type z --write-index=tbi " }
         ext.prefix = { "${meta.tumor_id}_${meta.normal_id}_sage_pass_only" }
     }
 

--- a/subworkflows/local/call_somatic_snvs/tests/nextflow.config
+++ b/subworkflows/local/call_somatic_snvs/tests/nextflow.config
@@ -1,0 +1,28 @@
+process {
+    withName: '.*CALL_SOMATIC_SNVS:VT_NORMALIZE' {
+        ext.prefix = { "${meta.tumor_id}_${meta.normal_id}_mutect2_filtered_normalized" }
+    }
+
+    withName: '.*CALL_SOMATIC_SNVS:INDEX_VCF' {
+        ext.args = { "-p vcf" }
+    }
+
+    withName: '.*CALL_SOMATIC_SNVS:PASSFILTER_FOR_MUTECT2' {
+        ext.args   = '--output-type z --write-index=tbi'
+        ext.prefix = { "${meta.tumor_id}_${meta.normal_id}_mutect2_pass_only" }
+    }
+
+    withName: '.*CALL_SOMATIC_SNVS:PASSFILTER_FOR_SAGE' {
+        ext.prefix = { "${meta.tumor_id}_${meta.normal_id}_sage_pass_only" }
+    }
+
+    withName: '.*CALL_SOMATIC_SNVS:SOMATIC_VCFMERGE' {
+        ext.prefix = { "${meta.tumor_id}_${meta.normal_id}" }
+    }
+
+    withName: '.*CALL_SOMATIC_SNVS:ANNOTATE_VEP' {
+        ext.args = { "--vcf --pick --check_existing --total_length --allele_number --no_escape --no_stats --everything --offline" }
+        ext.args2 = { "-p vcf" }
+        ext.prefix = { "${meta.tumor_id}_${meta.normal_id}-all.somatic.vep" }
+    }
+}


### PR DESCRIPTION
### Added

- nf-test for the `CALL_SOMATIC_SNVS` subworkflow covering a paired tumor/normal case and a stub case.
- `meta.yml` describing the subworkflow inputs and outputs.

Closes #67