### PR TITLE
fix: sort lane FASTQs before concatenation in UMI preprocessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Initial release of genomic-medicine-sweden/autoseq, created with the [nf-core](h
 - [ #72 ](https://github.com/genomic-medicine-sweden/autoseq/pull/72) Added `--sample` and `--library` to `FASTQTOBAM` so the read group sample name matches `meta.id` for downstream callers.
 - [ #73 ](https://github.com/genomic-medicine-sweden/autoseq/pull/73) Moved the `ZIPPERBAMS_(PRE|POST)` tag options from `ext.args` to `ext.args2` so they are passed to `ZipperBams` instead of to the fgbio wrapper.
 - [ #74 ](https://github.com/genomic-medicine-sweden/autoseq/pull/74) Collected the reference channel passed to `UMI_PROCESSING` so it is reusable across all samples instead of being consumed by the first one.
+- [ #94 ](https://github.com/genomic-medicine-sweden/autoseq/pull/94) Sorted grouped lane FASTQs by filename before `CAT_FASTQ` in the UMI branch, since `groupTuple` does not guarantee ordering and multi-lane samples could be concatenated in a non-reproducible order.
 
 ### `Dependencies`
 

--- a/workflows/autoseq.nf
+++ b/workflows/autoseq.nf
@@ -102,8 +102,12 @@ workflow AUTOSEQ {
             }
             .groupTuple()
             .map { _sample_name, grouped_reads ->
-                def metas = grouped_reads.collect{it -> it[0]}
-                def files = grouped_reads.collect{it -> it[1]}.flatten()
+                // groupTuple is unordered. Sort before concatenating to
+                // ensure consistent FASTQ read order and reproducible
+                // downstream results (alignments, UMIs, variants).
+                def sorted = grouped_reads.sort(false) { it -> it[1].name }
+                def metas = sorted.collect{it -> it[0]}
+                def files = sorted.collect{it -> it[1]}.flatten()
                 return [metas[0], files]
             }
             .set { ch_input_reads }


### PR DESCRIPTION
Closes #93

### Fixed

- Sort grouped lane FASTQs by filename before `CAT_FASTQ` in the UMI path (`workflows/autoseq.nf`). `groupTuple` makes no ordering guarantee, so a multi-lane sample could be concatenated in a different lane/read order between runs, making alignments and downstream variant calls non-reproducible.