### PR TITLE
docs: updated contribution guidelines - publishing strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Initial release of genomic-medicine-sweden/autoseq, created with the [nf-core](h
 - [ #57 ](https://github.com/genomic-medicine-sweden/autoseq/pull/57) Regenerated the `PREPARE_REFERENCES` nf-test snapshot to match the updated HMF `ensembl_data` reference CSVs.
 - [ #63 ](https://github.com/genomic-medicine-sweden/autoseq/pull/63) Updated the nf-core `fastq_create_umi_consensus_fgbio` subworkflow and its fgbio and samtools modules.
 - [ #91 ](https://github.com/genomic-medicine-sweden/autoseq/pull/91) Reference channels in `main.nf` now use `channelFromPathWithMeta`.
+- [ #95 ](https://github.com/genomic-medicine-sweden/autoseq/pull/95) Updated the contribution guidelines `docs/CONTRIBUTING.md` with new publishing strategy for pipeline outputs.
 
 ### `Fixed`
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -266,11 +266,10 @@ Please use the following naming schemes, to make it easy to understand what is g
 
 ### Publishing
 
-- Build a single `ch_publish` channel inside each subworkflow by mixing all publishable outputs into `[destination, value]` tuples.
-- The emit name must always be `publish = ch_publish` — never the bare shorthand.
-- Group channels that share a destination with `mix` first, then apply **one** `.map` per destination group — never one map per channel.
-- If your subworkflow calls inner subworkflows, always mix their `.out.publish` into the outer `ch_publish`. Never discard it.
-- Remove the corresponding `publishDir` entry from `conf/modules/` when adding a process to `ch_publish`.
+- All workflows and subworkflows must include an `emit` block including all publishable outputs (e.g. files), with explanatory names and ordered alphabetically.
+- The main workflow includes logic to mix together all outputs that should be published in the same output directory (i.e. one item per output directory).
+- The `publish` block includes all items above, with explanatory names and ordered alphabetically.
+- The `output` block lists all the publishable items and specifies the output directory corresponding to each item.
 
 ### Configuration
 


### PR DESCRIPTION

### Changed
- Update the new publishing strategy in the contribution guidelines `docs/CONTRIBUTING.md`
