### PR TITLE
feat: add annotate_germline_taf subworkflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Initial release of genomic-medicine-sweden/autoseq, created with the [nf-core](h
 - [ #89 ](https://github.com/genomic-medicine-sweden/autoseq/pull/89) Added nf-test and `meta.yml` for the `CALL_SVS` subworkflow covering a paired tumor/normal case and a stub case.
 - [ #90 ](https://github.com/genomic-medicine-sweden/autoseq/pull/90) Added nf-test and `meta.yml` for the `CALL_SOMATIC_SNVS` subworkflow covering a paired tumor/normal case and a stub case.
 - [ #91 ](https://github.com/genomic-medicine-sweden/autoseq/pull/91) Added the `channelFromPathWithMeta` helper to build `[[id:...], file]` reference channels from a path, or `channel.empty()` when the path is null.
+- [ #96 ](https://github.com/genomic-medicine-sweden/autoseq/pull/96) Added the `ANNOTATE_GERMLINE_TAF` subworkflow to annotate germline variants with the tumor allele fraction, with nf-test and `meta.yml`.
 
 ### `Changed`
 

--- a/modules.json
+++ b/modules.json
@@ -10,6 +10,11 @@
                         "git_sha": "f17049e03697726ace7499d2fe342f892594f6f3",
                         "installed_by": ["modules"]
                     },
+                    "bcftools/merge": {
+                        "branch": "master",
+                        "git_sha": "feef37435aea56816adf4b3bde1fc76aac327a8d",
+                        "installed_by": ["modules"]
+                    },
                     "bwa/index": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
@@ -89,6 +94,11 @@
                         "branch": "master",
                         "git_sha": "a57253204b8f4022edfeaa3ae2f5e2abecd8858b",
                         "installed_by": ["bam_tumor_normal_somatic_variant_calling_gatk"]
+                    },
+                    "gatk4/genotypegvcfs": {
+                        "branch": "master",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
+                        "installed_by": ["modules"]
                     },
                     "gatk4/getpileupsummaries": {
                         "branch": "master",

--- a/modules/nf-core/bcftools/merge/environment.yml
+++ b/modules/nf-core/bcftools/merge/environment.yml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  # renovate: datasource=conda depName=bioconda/bcftools
+  - bioconda::bcftools=1.23.1
+  # renovate: datasource=conda depName=bioconda/htslib
+  - bioconda::htslib=1.23.1

--- a/modules/nf-core/bcftools/merge/main.nf
+++ b/modules/nf-core/bcftools/merge/main.nf
@@ -1,0 +1,73 @@
+process BCFTOOLS_MERGE {
+    tag "${meta.id}"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/0b/0b4d52ca9a56d07be3f78a12af654e5116f5112908dba277e6796fd9dfb83fe5/data'
+        : 'community.wave.seqera.io/library/bcftools_htslib:1.23.1--9f08ec665533d64a'}"
+
+    input:
+    tuple val(meta), path(vcfs), path(tbis), path(bed)
+    tuple val(meta2), path(fasta), path(fai)
+
+    output:
+    tuple val(meta), path("*.{bcf,vcf}{,.gz}"), emit: vcf
+    tuple val(meta), path("*.{csi,tbi}"), emit: index, optional: true
+    tuple val("${task.process}"), val('bcftools'), eval("bcftools --version | sed '1!d; s/^.*bcftools //'"), topic: versions, emit: versions_bcftools
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    def input = vcfs.collect().size() > 1 ? vcfs.sort { vcf -> vcf.name } : vcfs
+    def regions = bed ? "--regions-file ${bed}" : ""
+    def extension = args.contains("--output-type b") || args.contains("-Ob")
+        ? "bcf.gz"
+        : args.contains("--output-type u") || args.contains("-Ou")
+            ? "bcf"
+            : args.contains("--output-type z") || args.contains("-Oz")
+                ? "vcf.gz"
+                : args.contains("--output-type v") || args.contains("-Ov")
+                    ? "vcf"
+                    : "vcf"
+
+    """
+    bcftools merge \\
+        ${args} \\
+        ${regions} \\
+        --threads ${task.cpus} \\
+        --output ${prefix}.${extension} \\
+        ${input}
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def extension = args.contains("--output-type b") || args.contains("-Ob")
+        ? "bcf.gz"
+        : args.contains("--output-type u") || args.contains("-Ou")
+            ? "bcf"
+            : args.contains("--output-type z") || args.contains("-Oz")
+                ? "vcf.gz"
+                : args.contains("--output-type v") || args.contains("-Ov")
+                    ? "vcf"
+                    : "vcf"
+    def index = args.contains("--write-index=tbi") || args.contains("-W=tbi")
+        ? "tbi"
+        : args.contains("--write-index=csi") || args.contains("-W=csi")
+            ? "csi"
+            : args.contains("--write-index") || args.contains("-W")
+                ? "csi"
+                : ""
+    def create_cmd = extension.endsWith(".gz") ? "echo '' | gzip >" : "touch"
+    def create_index = extension.endsWith(".gz") && index.matches("csi|tbi") ? "touch ${prefix}.${extension}.${index}" : ""
+
+    """
+    ${create_cmd} ${prefix}.${extension}
+    ${create_index}
+    """
+}

--- a/modules/nf-core/bcftools/merge/meta.yml
+++ b/modules/nf-core/bcftools/merge/meta.yml
@@ -1,0 +1,110 @@
+name: bcftools_merge
+description: Merge VCF files
+keywords:
+  - variant calling
+  - merge
+  - VCF
+tools:
+  - merge:
+      description: |
+        Merge VCF files.
+      homepage: http://samtools.github.io/bcftools/bcftools.html
+      documentation: http://www.htslib.org/doc/bcftools.html
+      doi: 10.1093/bioinformatics/btp352
+      licence:
+        - "MIT"
+      identifier: biotools:bcftools
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - vcfs:
+        type: file
+        description: |
+          List containing 2 or more vcf files
+          e.g. [ 'file1.vcf', 'file2.vcf' ]
+        ontologies: []
+    - tbis:
+        type: file
+        description: |
+          List containing the tbi index files corresponding to the vcfs input files
+          e.g. [ 'file1.vcf.tbi', 'file2.vcf.tbi' ]
+        ontologies: []
+    - bed:
+        type: file
+        description: "(Optional) The bed regions to merge on"
+        pattern: "*.bed"
+        ontologies: []
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing reference information
+          e.g. [ id:'genome' ]
+    - fasta:
+        type: file
+        description: "(Optional) The fasta reference file (only necessary for the `--gvcf
+          FILE` parameter)"
+        pattern: "*.{fasta,fa}"
+        ontologies: []
+    - fai:
+        type: file
+        description: "(Optional) The fasta reference file index (only necessary for
+          the `--gvcf FILE` parameter)"
+        pattern: "*.fai"
+        ontologies: []
+output:
+  vcf:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.{bcf,vcf}{,.gz}":
+          type: file
+          description: merged output file
+          pattern: "*.{vcf,vcf.gz,bcf,bcf.gz}"
+          ontologies: []
+  index:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.{csi,tbi}":
+          type: file
+          description: index of merged output
+          pattern: "*.{csi,tbi}"
+          ontologies: []
+  versions_bcftools:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - bcftools:
+          type: string
+          description: The tool name
+      - "bcftools --version | sed '1!d; s/^.*bcftools //'":
+          type: eval
+          description: The command used to generate the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - bcftools:
+          type: string
+          description: The tool name
+      - "bcftools --version | sed '1!d; s/^.*bcftools //'":
+          type: eval
+          description: The command used to generate the version of the tool
+authors:
+  - "@joseespinosa"
+  - "@drpatelh"
+  - "@nvnieuwk"
+  - "@ramprasadn"
+maintainers:
+  - "@joseespinosa"
+  - "@drpatelh"
+  - "@nvnieuwk"
+  - "@ramprasadn"

--- a/modules/nf-core/bcftools/merge/tests/main.nf.test
+++ b/modules/nf-core/bcftools/merge/tests/main.nf.test
@@ -1,0 +1,719 @@
+nextflow_process {
+
+    name "Test Process BCFTOOLS_MERGE"
+    script "../main.nf"
+    config "./nextflow.config"
+
+    process "BCFTOOLS_MERGE"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "bcftools"
+    tag "bcftools/merge"
+
+    test("sarscov2 - [vcf, tbi], [], [], []") {
+
+        when {
+            params {
+                args_modules = "--force-samples --force-single --no-version"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz.tbi', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz.tbi', checkIfExists: true),
+                    ],
+                    []
+                ]
+                input[1] = [[],[],[]]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.vcf.get(0).get(1).endsWith("vcf") },
+                { assert snapshot(
+                    path(process.out.vcf.get(0).get(1)).vcf.variantsMD5,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - vcf output") {
+
+        when {
+            params {
+                args_modules = "--output-type v --no-version"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz.tbi', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz.tbi', checkIfExists: true),
+                    ],
+                    []
+                ]
+                input[1] = [[],[],[]]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.vcf.get(0).get(1).endsWith("vcf") },
+                { assert snapshot(
+                    path(process.out.vcf.get(0).get(1)).md5,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - vcf.gz output") {
+
+        when {
+            params {
+                args_modules = "--output-type z --no-version"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz.tbi', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz.tbi', checkIfExists: true),
+                    ],
+                    []
+                ]
+                input[1] = [[],[],[]]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.vcf.get(0).get(1).endsWith("vcf.gz") },
+                { assert snapshot(
+                    path(process.out.vcf.get(0).get(1)).vcf.variantsMD5,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - bcf output") {
+
+        when {
+            params {
+                args_modules = "--output-type u --no-version"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz.tbi', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz.tbi', checkIfExists: true),
+                    ],
+                    []
+                ]
+                input[1] = [[],[],[]]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.vcf.get(0).get(1).endsWith("bcf") },
+                { assert snapshot(
+                    file(process.out.vcf.get(0).get(1)).name,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - bcf.gz output") {
+
+        when {
+            params {
+                args_modules = "--output-type b --no-version"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz.tbi', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz.tbi', checkIfExists: true),
+                    ],
+                    []
+                ]
+                input[1] = [[],[],[]]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.vcf.get(0).get(1).endsWith("bcf.gz") },
+                { assert snapshot(
+                    file(process.out.vcf.get(0).get(1)).name,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - vcf.gz output - index") {
+
+        when {
+            params {
+                args_modules = "--output-type z --write-index --no-version"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz.tbi', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz.tbi', checkIfExists: true),
+                    ],
+                    []
+                ]
+                input[1] = [[],[],[]]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.vcf.get(0).get(1).endsWith("vcf.gz") },
+                { assert process.out.index.get(0).get(1).endsWith("csi") },
+                { assert snapshot(
+                    path(process.out.vcf.get(0).get(1)).vcf.variantsMD5,
+                    file(process.out.index.get(0).get(1)).name,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - vcf.gz output - csi index") {
+
+        when {
+            params {
+                args_modules = "--output-type z --write-index=csi --no-version"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz.tbi', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz.tbi', checkIfExists: true),
+                    ],
+                    []
+                ]
+                input[1] = [[],[],[]]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.vcf.get(0).get(1).endsWith("vcf.gz") },
+                { assert process.out.index.get(0).get(1).endsWith("csi") },
+                { assert snapshot(
+                    path(process.out.vcf.get(0).get(1)).vcf.variantsMD5,
+                    file(process.out.index.get(0).get(1)).name,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - vcf.gz output - tbi index") {
+
+        when {
+            params {
+                args_modules = "--output-type z --write-index=tbi --no-version"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz.tbi', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz.tbi', checkIfExists: true),
+                    ],
+                    []
+                ]
+                input[1] = [[],[],[]]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.vcf.get(0).get(1).endsWith("vcf.gz") },
+                { assert process.out.index.get(0).get(1).endsWith("tbi") },
+                { assert snapshot(
+                    path(process.out.vcf.get(0).get(1)).vcf.variantsMD5,
+                    file(process.out.index.get(0).get(1)).name,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], bed") {
+
+        when {
+            params {
+                args_modules = "--force-samples --force-single --no-version"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz.tbi', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz.tbi', checkIfExists: true),
+                    ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/bed/test.bed', checkIfExists: true)
+                ]
+                input[1] = [[],[],[]]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.vcf.get(0).get(1).endsWith("vcf") },
+                { assert snapshot(
+                    path(process.out.vcf.get(0).get(1)).md5,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
+                ).match() }
+            )
+        }
+    }
+
+    test("homo_sapiens - [vcf, tbi], fasta, fai, bed  - vcf.gz output") {
+
+        when {
+            params {
+                args_modules = "--force-samples --no-version --output-type z --gvcf genome.fasta"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gvcf/test2.genome.vcf.gz', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.gz.tbi', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gvcf/test2.genome.vcf.gz.tbi', checkIfExists: true),
+                    ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.bed', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'test' ], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true) ],
+                    [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true) ]
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.vcf.get(0).get(1).endsWith("vcf.gz") },
+                { assert snapshot(
+                    path(process.out.vcf.get(0).get(1)).vcf.variantsMD5,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - one sample") {
+
+        when {
+            params {
+                args_modules = "--force-samples --force-single --no-version"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz.tbi', checkIfExists: true)
+                    ],
+                    []
+                ]
+                input[1] = [[],[],[]]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.vcf.get(0).get(1).endsWith("vcf") },
+                { assert snapshot(
+                    path(process.out.vcf.get(0).get(1)).md5,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                args_modules = "--force-samples --force-single --no-version"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz.tbi', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz.tbi', checkIfExists: true),
+                    ],
+                    []
+                ]
+                input[1] = [[],[],[]]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.vcf.get(0).get(1).endsWith("vcf") },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - vcf output - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                args_modules = "--output-type v --no-version"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz.tbi', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz.tbi', checkIfExists: true),
+                    ],
+                    []
+                ]
+                input[1] = [[],[],[]]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.vcf.get(0).get(1).endsWith("vcf") },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - vcf.gz output - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                args_modules = "--output-type z --no-version"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz.tbi', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz.tbi', checkIfExists: true),
+                    ],
+                    []
+                ]
+                input[1] = [[],[],[]]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.vcf.get(0).get(1).endsWith("vcf.gz") },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - bcf output - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                args_modules = "--output-type u --no-version"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz.tbi', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz.tbi', checkIfExists: true),
+                    ],
+                    []
+                ]
+                input[1] = [[],[],[]]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.vcf.get(0).get(1).endsWith("bcf") },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - bcf.gz output - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                args_modules = "--output-type b --no-version"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz.tbi', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz.tbi', checkIfExists: true),
+                    ],
+                    []
+                ]
+                input[1] = [[],[],[]]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.vcf.get(0).get(1).endsWith("bcf.gz") },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - vcf.gz output - index - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                args_modules = "--output-type z --write-index --no-version"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz.tbi', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz.tbi', checkIfExists: true),
+                    ],
+                    []
+                ]
+                input[1] = [[],[],[]]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.vcf.get(0).get(1).endsWith("vcf.gz") },
+                { assert process.out.index.get(0).get(1).endsWith("csi") },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - vcf.gz output - csi index - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                args_modules = "--output-type z --write-index=csi --no-version"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz.tbi', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz.tbi', checkIfExists: true),
+                    ],
+                    []
+                ]
+                input[1] = [[],[],[]]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.vcf.get(0).get(1).endsWith("vcf.gz") },
+                { assert process.out.index.get(0).get(1).endsWith("csi") },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - vcf.gz output - tbi index - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                args_modules = "--output-type z --write-index=tbi --no-version"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz.tbi', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz.tbi', checkIfExists: true),
+                    ],
+                    []
+                ]
+                input[1] = [[],[],[]]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.vcf.get(0).get(1).endsWith("vcf.gz") },
+                { assert process.out.index.get(0).get(1).endsWith("tbi") },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/bcftools/merge/tests/main.nf.test.snap
+++ b/modules/nf-core/bcftools/merge/tests/main.nf.test.snap
@@ -1,0 +1,620 @@
+{
+    "sarscov2 - [vcf, tbi], [], [], [] - vcf.gz output - tbi index": {
+        "content": [
+            "e0de448dc8e712956a03ce68d79a0b3a",
+            "test.vcf.gz.tbi",
+            {
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_MERGE",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-20T18:04:45.080843391",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.2"
+        }
+    },
+    "sarscov2 - [vcf, tbi], [], [], [] - vcf output - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.vcf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    [
+                        "BCFTOOLS_MERGE",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ],
+                "index": [
+                    
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.vcf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_MERGE",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-20T18:05:25.25403025",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.2"
+        }
+    },
+    "sarscov2 - [vcf, tbi], [], [], bed": {
+        "content": [
+            "febdcfb851dcfc83d8248520830aef10",
+            {
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_MERGE",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-20T18:04:52.858929503",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.2"
+        }
+    },
+    "sarscov2 - [vcf, tbi], [], [], [] - vcf.gz output - index - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.vcf.gz.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        "BCFTOOLS_MERGE",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ],
+                "index": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.vcf.gz.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_MERGE",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-20T18:05:56.583006641",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.2"
+        }
+    },
+    "sarscov2 - [vcf, tbi], [], [], [] - vcf output": {
+        "content": [
+            "57bb84274f336465d0a0946b532093b0",
+            {
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_MERGE",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-20T18:03:57.570236761",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.2"
+        }
+    },
+    "sarscov2 - [vcf, tbi], [], [], [] - bcf.gz output - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    [
+                        "BCFTOOLS_MERGE",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ],
+                "index": [
+                    
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_MERGE",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-20T18:05:48.75796761",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.2"
+        }
+    },
+    "sarscov2 - [vcf, tbi], [], [], [] - vcf.gz output - tbi index - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.vcf.gz.tbi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        "BCFTOOLS_MERGE",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ],
+                "index": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.vcf.gz.tbi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_MERGE",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-20T18:06:11.006590962",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.2"
+        }
+    },
+    "sarscov2 - [vcf, tbi], [], [], [] - vcf.gz output - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    [
+                        "BCFTOOLS_MERGE",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ],
+                "index": [
+                    
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_MERGE",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-20T18:05:33.181550902",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.2"
+        }
+    },
+    "sarscov2 - [vcf, tbi], [], [], [] - vcf.gz output - csi index": {
+        "content": [
+            "e0de448dc8e712956a03ce68d79a0b3a",
+            "test.vcf.gz.csi",
+            {
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_MERGE",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-20T18:04:37.289045617",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.2"
+        }
+    },
+    "sarscov2 - [vcf, tbi], [], [], [] - vcf.gz output": {
+        "content": [
+            "e0de448dc8e712956a03ce68d79a0b3a",
+            {
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_MERGE",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-20T18:04:05.940999977",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.2"
+        }
+    },
+    "sarscov2 - [vcf, tbi], [], [], [] - bcf output": {
+        "content": [
+            "test.bcf",
+            {
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_MERGE",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-20T18:04:13.622386289",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.2"
+        }
+    },
+    "sarscov2 - [vcf, tbi], [], [], [] - bcf output - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bcf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    [
+                        "BCFTOOLS_MERGE",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ],
+                "index": [
+                    
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bcf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_MERGE",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-20T18:05:41.084610701",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.2"
+        }
+    },
+    "sarscov2 - [vcf, tbi], [], [], [] - vcf.gz output - index": {
+        "content": [
+            "e0de448dc8e712956a03ce68d79a0b3a",
+            "test.vcf.gz.csi",
+            {
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_MERGE",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-20T18:04:29.469178039",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.2"
+        }
+    },
+    "homo_sapiens - [vcf, tbi], fasta, fai, bed  - vcf.gz output": {
+        "content": [
+            "645b7f7f9131bfe350a9ec3cf82c17fe",
+            {
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_MERGE",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-20T18:05:01.918013292",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.2"
+        }
+    },
+    "sarscov2 - [vcf, tbi], [], [], [] - one sample": {
+        "content": [
+            "2a374cf02f0c32cf607646167e7f153b",
+            {
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_MERGE",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-20T18:05:09.444730199",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.2"
+        }
+    },
+    "sarscov2 - [vcf, tbi], [], [], [] - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.vcf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    [
+                        "BCFTOOLS_MERGE",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ],
+                "index": [
+                    
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.vcf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_MERGE",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-20T18:05:16.820762299",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.2"
+        }
+    },
+    "sarscov2 - [vcf, tbi], [], [], [] - vcf.gz output - csi index - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.vcf.gz.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        "BCFTOOLS_MERGE",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ],
+                "index": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.vcf.gz.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_MERGE",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-20T18:06:03.842949519",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.2"
+        }
+    },
+    "sarscov2 - [vcf, tbi], [], [], []": {
+        "content": [
+            "e0de448dc8e712956a03ce68d79a0b3a",
+            {
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_MERGE",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-20T18:03:49.803735629",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.2"
+        }
+    },
+    "sarscov2 - [vcf, tbi], [], [], [] - bcf.gz output": {
+        "content": [
+            "test.bcf.gz",
+            {
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_MERGE",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-20T18:04:20.850645013",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.2"
+        }
+    }
+}

--- a/modules/nf-core/bcftools/merge/tests/nextflow.config
+++ b/modules/nf-core/bcftools/merge/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: BCFTOOLS_MERGE {
+        ext.args = "${params.args_modules}"
+    }
+}

--- a/modules/nf-core/gatk4/genotypegvcfs/environment.yml
+++ b/modules/nf-core/gatk4/genotypegvcfs/environment.yml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  # renovate: datasource=conda depName=bioconda/gatk4
+  - bioconda::gatk4=4.6.2.0
+  # renovate: datasource=conda depName=bioconda/gcnvkernel
+  - bioconda::gcnvkernel=0.9

--- a/modules/nf-core/gatk4/genotypegvcfs/main.nf
+++ b/modules/nf-core/gatk4/genotypegvcfs/main.nf
@@ -1,0 +1,59 @@
+process GATK4_GENOTYPEGVCFS {
+    tag "${meta.id}"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/ce/ced519873646379e287bc28738bdf88e975edd39a92e7bc6a34bccd37153d9d0/data'
+        : 'community.wave.seqera.io/library/gatk4_gcnvkernel:edb12e4f0bf02cd3'}"
+
+    input:
+    tuple val(meta), path(input), path(gvcf_index), path(intervals), path(intervals_index)
+    tuple val(meta2), path(fasta)
+    tuple val(meta3), path(fai)
+    tuple val(meta4), path(dict)
+    tuple val(meta5), path(dbsnp)
+    tuple val(meta6), path(dbsnp_tbi)
+
+    output:
+    tuple val(meta), path("*.vcf.gz"), emit: vcf
+    tuple val(meta), path("*.tbi"), emit: tbi
+    tuple val("${task.process}"), val('gatk4'), eval("gatk --version | sed -n '/GATK.*v/s/.*v//p'"), topic: versions, emit: versions_gatk4
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def input_command = input.name.endsWith(".vcf") || input.name.endsWith(".vcf.gz") ? "${input}" : "gendb://${input}"
+    def dbsnp_command = dbsnp ? "--dbsnp ${dbsnp}" : ""
+    def interval_command = intervals ? "--intervals ${intervals}" : ""
+
+    def avail_mem = 3072
+    if (!task.memory) {
+        log.info('[GATK GenotypeGVCFs] Available memory not known - defaulting to 3GB. Specify process memory requirements to change this.')
+    }
+    else {
+        avail_mem = (task.memory.mega * 0.8).intValue()
+    }
+    """
+    gatk --java-options "-Xmx${avail_mem}M -XX:-UsePerfData" \\
+        GenotypeGVCFs \\
+        --variant ${input_command} \\
+        --output ${prefix}.vcf.gz \\
+        --reference ${fasta} \\
+        ${interval_command} \\
+        ${dbsnp_command} \\
+        --tmp-dir . \\
+        ${args}
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    """
+    echo | gzip > ${prefix}.vcf.gz
+    touch ${prefix}.vcf.gz.tbi
+    """
+}

--- a/modules/nf-core/gatk4/genotypegvcfs/meta.yml
+++ b/modules/nf-core/gatk4/genotypegvcfs/meta.yml
@@ -1,0 +1,147 @@
+name: gatk4_genotypegvcfs
+description: |
+  Perform joint genotyping on one or more samples pre-called with HaplotypeCaller.
+keywords:
+  - gatk4
+  - genotype
+  - gvcf
+  - joint genotyping
+tools:
+  - gatk4:
+      description: Genome Analysis Toolkit (GATK4)
+      homepage: https://gatk.broadinstitute.org/hc/en-us
+      documentation: https://gatk.broadinstitute.org/hc/en-us/categories/360002369672s
+      tool_dev_url: https://github.com/broadinstitute/gatk
+      doi: "10.1158/1538-7445.AM2017-3590"
+      licence: ["BSD-3-clause"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - input:
+        type: file
+        description: |
+          gVCF(.gz) file or a GenomicsDB
+        pattern: "*.{vcf,vcf.gz}"
+        ontologies: []
+    - gvcf_index:
+        type: file
+        description: |
+          index of gvcf file, or empty when providing GenomicsDB
+        pattern: "*.{idx,tbi}"
+        ontologies: []
+    - intervals:
+        type: file
+        description: Interval file with the genomic regions included in the library
+          (optional)
+        ontologies: []
+    - intervals_index:
+        type: file
+        description: Interval index file (optional)
+        ontologies: []
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing fasta information
+          e.g. [ id:'test' ]
+    - fasta:
+        type: file
+        description: Reference fasta file
+        pattern: "*.fasta"
+        ontologies: []
+  - - meta3:
+        type: map
+        description: |
+          Groovy Map containing fai information
+          e.g. [ id:'test' ]
+    - fai:
+        type: file
+        description: Reference fasta index file
+        pattern: "*.fai"
+        ontologies: []
+  - - meta4:
+        type: map
+        description: |
+          Groovy Map containing dict information
+          e.g. [ id:'test' ]
+    - dict:
+        type: file
+        description: Reference fasta sequence dict file
+        pattern: "*.dict"
+        ontologies: []
+  - - meta5:
+        type: map
+        description: |
+          Groovy Map containing dbsnp information
+          e.g. [ id:'test' ]
+    - dbsnp:
+        type: file
+        description: dbSNP VCF file
+        pattern: "*.vcf.gz"
+        ontologies:
+          - edam: http://edamontology.org/format_3989 # GZIP format
+  - - meta6:
+        type: map
+        description: |
+          Groovy Map containing dbsnp tbi information
+          e.g. [ id:'test' ]
+    - dbsnp_tbi:
+        type: file
+        description: dbSNP VCF index file
+        pattern: "*.tbi"
+        ontologies: []
+output:
+  vcf:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.vcf.gz":
+          type: file
+          description: Genotyped VCF file
+          pattern: "*.vcf.gz"
+          ontologies:
+            - edam: http://edamontology.org/format_3989 # GZIP format
+  tbi:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.tbi":
+          type: file
+          description: Tbi index for VCF file
+          pattern: "*.vcf.gz"
+          ontologies:
+            - edam: http://edamontology.org/format_3989 # GZIP format
+  versions_gatk4:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - gatk4:
+          type: string
+          description: The name of the tool
+      - gatk --version | sed -n '/GATK.*v/s/.*v//p':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - gatk4:
+          type: string
+          description: The name of the tool
+      - gatk --version | sed -n '/GATK.*v/s/.*v//p':
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@santiagorevale"
+  - "@maxulysse"
+maintainers:
+  - "@santiagorevale"
+  - "@maxulysse"

--- a/modules/nf-core/gatk4/genotypegvcfs/tests/main.nf.test
+++ b/modules/nf-core/gatk4/genotypegvcfs/tests/main.nf.test
@@ -1,0 +1,278 @@
+nextflow_process {
+
+    name "Test Process GATK4_GENOTYPEGVCFS"
+    script "../main.nf"
+    process "GATK4_GENOTYPEGVCFS"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "gatk4"
+    tag "gatk4/genotypegvcfs"
+    tag "untar"
+
+    setup {
+        run("UNTAR") {
+            script "../../../untar/main.nf"
+            process {
+                """
+                input[0] = [
+                    [id:"test"],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gatk/test_genomicsdb.tar.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+    }
+
+    test("homo_sapiens - [gvcf, idx, [], []], fasta, fai, dict, [], []") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [id:"test"],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gvcf/test.genome.vcf', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.idx', checkIfExists: true),
+                    [],
+                    []
+                ]
+                input[1] = [
+                    [id:"fasta"],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists:true)
+                ]
+                input[2] = [
+                    [id:"fai"],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists:true)
+                ]
+                input[3] = [
+                    [id:"dict"],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.dict', checkIfExists:true)
+                ]
+                input[4] = [[],[]]
+                input[5] = [[],[]]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(
+                    process.out.vcf.collect { [it[0], path(it[1]).vcf.variantsMD5] },
+                    process.out.tbi.collect { [it[0], file(it[1]).name] },
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                ).match() }
+            )
+        }
+    }
+
+    test("homo_sapiens - [gvcf_gz, tbi, [], []], fasta, fai, dict, dbsnp, dbsnp_tbi") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [id:"test"],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.gz.tbi', checkIfExists: true),
+                    [],
+                    []
+                ]
+                input[1] = [
+                    [id:"fasta"],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists:true)
+                ]
+                input[2] = [
+                    [id:"fai"],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists:true)
+                ]
+                input[3] = [
+                    [id:"dict"],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.dict', checkIfExists:true)
+                ]
+                input[4] = [
+                    [id:"dbsnp"],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/vcf/dbsnp_146.hg38.vcf.gz', checkIfExists:true)
+                ]
+                input[5] = [
+                    [id:"dbsnp"],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/vcf/dbsnp_146.hg38.vcf.gz.tbi', checkIfExists:true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(
+                    process.out.vcf.collect { [it[0], path(it[1]).vcf.variantsMD5] },
+                    process.out.tbi.collect { [it[0], file(it[1]).name] },
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                ).match() }
+            )
+        }
+    }
+
+    test("homo_sapiens - [gvcf_gz, tbi, bed, []], fasta, fai, dict, [], []") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [id:"test"],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.gz.tbi', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.bed', checkIfExists:true),
+                    []
+                ]
+                input[1] = [
+                    [id:"fasta"],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists:true)
+                ]
+                input[2] = [
+                    [id:"fai"],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists:true)
+                ]
+                input[3] = [
+                    [id:"dict"],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.dict', checkIfExists:true)
+                ]
+                input[4] = [[],[]]
+                input[5] = [[],[]]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(
+                    process.out.vcf.collect { [it[0], path(it[1]).vcf.variantsMD5] },
+                    process.out.tbi.collect { [it[0], file(it[1]).name] },
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                ).match() }
+            )
+        }
+    }
+
+    test("homo_sapiens - [gendb, [], [], []], fasta, fai, dict, [], []") {
+
+        when {
+            process {
+                """
+                input[0] = UNTAR.out.untar.map { meta, gendb -> [ meta, gendb, [], [], []] }
+                input[1] = [
+                    [id:"fasta"],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists:true)
+                ]
+                input[2] = [
+                    [id:"fai"],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists:true)
+                ]
+                input[3] = [
+                    [id:"dict"],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.dict', checkIfExists:true)
+                ]
+                input[4] = [[],[]]
+                input[5] = [[],[]]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(
+                    process.out.vcf.collect { [it[0], path(it[1]).vcf.variantsMD5] },
+                    process.out.tbi.collect { [it[0], file(it[1]).name] },
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                ).match() }
+            )
+        }
+    }
+
+    test("homo_sapiens - [gendb, bed, [], []], fasta, fai, dict, [], []") {
+
+        when {
+            process {
+                """
+                input[0] = UNTAR.out.untar.map { meta, gendb ->
+                    [
+                        meta,
+                        gendb,
+                        [],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.bed', checkIfExists:true),
+                        []
+                    ]
+                }
+                input[1] = [
+                    [id:"fasta"],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists:true)
+                ]
+                input[2] = [
+                    [id:"fai"],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists:true)
+                ]
+                input[3] = [
+                    [id:"dict"],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.dict', checkIfExists:true)
+                ]
+                input[4] = [[],[]]
+                input[5] = [[],[]]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(
+                    process.out.vcf.collect { [it[0], path(it[1]).vcf.variantsMD5] },
+                    process.out.tbi.collect { [it[0], file(it[1]).name] },
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                ).match() }
+            )
+        }
+    }
+
+    test("homo_sapiens - [gvcf, idx, [], []], fasta, fai, dict, [], [] - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [id:"test"],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gvcf/test.genome.vcf', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.idx', checkIfExists: true),
+                    [],
+                    []
+                ]
+                input[1] = [
+                    [id:"fasta"],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists:true)
+                ]
+                input[2] = [
+                    [id:"fai"],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists:true)
+                ]
+                input[3] = [
+                    [id:"dict"],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.dict', checkIfExists:true)
+                ]
+                input[4] = [[],[]]
+                input[5] = [[],[]]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/gatk4/genotypegvcfs/tests/main.nf.test.snap
+++ b/modules/nf-core/gatk4/genotypegvcfs/tests/main.nf.test.snap
@@ -1,0 +1,229 @@
+{
+    "homo_sapiens - [gendb, [], [], []], fasta, fai, dict, [], []": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "1ab95fbc5ec55b208f3001572bec54fa"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.vcf.gz.tbi"
+                ]
+            ],
+            {
+                "versions_gatk4": [
+                    [
+                        "GATK4_GENOTYPEGVCFS",
+                        "gatk4",
+                        "4.6.2.0"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
+        },
+        "timestamp": "2026-02-05T15:46:34.634470581"
+    },
+    "homo_sapiens - [gvcf, idx, [], []], fasta, fai, dict, [], []": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "1ab95fbc5ec55b208f3001572bec54fa"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.vcf.gz.tbi"
+                ]
+            ],
+            {
+                "versions_gatk4": [
+                    [
+                        "GATK4_GENOTYPEGVCFS",
+                        "gatk4",
+                        "4.6.2.0"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
+        },
+        "timestamp": "2026-02-05T15:46:11.446056396"
+    },
+    "homo_sapiens - [gvcf_gz, tbi, bed, []], fasta, fai, dict, [], []": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "1ab95fbc5ec55b208f3001572bec54fa"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.vcf.gz.tbi"
+                ]
+            ],
+            {
+                "versions_gatk4": [
+                    [
+                        "GATK4_GENOTYPEGVCFS",
+                        "gatk4",
+                        "4.6.2.0"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
+        },
+        "timestamp": "2026-02-05T15:46:26.768611757"
+    },
+    "homo_sapiens - [gvcf_gz, tbi, [], []], fasta, fai, dict, dbsnp, dbsnp_tbi": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "9b7d476515e07e5486633c42abd86cc"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.vcf.gz.tbi"
+                ]
+            ],
+            {
+                "versions_gatk4": [
+                    [
+                        "GATK4_GENOTYPEGVCFS",
+                        "gatk4",
+                        "4.6.2.0"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
+        },
+        "timestamp": "2026-02-05T15:46:18.984426817"
+    },
+    "homo_sapiens - [gvcf, idx, [], []], fasta, fai, dict, [], [] - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.vcf.gz.tbi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        "GATK4_GENOTYPEGVCFS",
+                        "gatk4",
+                        "4.6.2.0"
+                    ]
+                ],
+                "tbi": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.vcf.gz.tbi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions_gatk4": [
+                    [
+                        "GATK4_GENOTYPEGVCFS",
+                        "gatk4",
+                        "4.6.2.0"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
+        },
+        "timestamp": "2026-02-05T15:46:49.187479725"
+    },
+    "homo_sapiens - [gendb, bed, [], []], fasta, fai, dict, [], []": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "1ab95fbc5ec55b208f3001572bec54fa"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.vcf.gz.tbi"
+                ]
+            ],
+            {
+                "versions_gatk4": [
+                    [
+                        "GATK4_GENOTYPEGVCFS",
+                        "gatk4",
+                        "4.6.2.0"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
+        },
+        "timestamp": "2026-02-05T15:46:43.108044727"
+    }
+}

--- a/subworkflows/local/annotate_germline_taf/main.nf
+++ b/subworkflows/local/annotate_germline_taf/main.nf
@@ -5,65 +5,83 @@ include { BCFTOOLS_MERGE        } from '../../../modules/nf-core/bcftools/merge/
 
 workflow ANNOTATE_GERMLINE_TAF {
     take:
-    ch_tbam_gvcf        // channel: [mandatory] input channel of tumor bam and germline vep vcf files
-    ch_genome_fasta     // channel: [mandatory] input channel of reference genome fasta file
-    ch_genome_fai       // channel: [mandatory] input channel of reference genome fai file
-    ch_genome_dict      // channel: [mandatory] input channel of reference genome dict file
+    ch_tbam_gvcf        // channel: [mandatory] [ val(meta), path(tbam), path(tbai), path(gvcf), path(gvcf_tbi) ]
+    ch_genome_fasta     // channel: [mandatory] [ val(meta), path(fasta) ]
+    ch_genome_fai       // channel: [mandatory] [ val(meta), path(fai) ]
+    ch_genome_dict      // channel: [mandatory] [ val(meta), path(dict) ]
 
     main:
 
-    def ch_input_haplotypecaller = ch_tbam_gvcf
-        .map { meta, tbam, tbai, gvcf, gvcf_tbi ->
+    def ch_versions = channel.empty()
+
+    // The germline VCF is passed through the `intervals` slot so that the tumour is
+    // genotyped only at the sites where a germline variant was called
+    def ch_tbam_gvcf_for_haplotypecaller = ch_tbam_gvcf
+        .map { meta, tbam, tbai, gvcf, _gvcf_tbi ->
             return [meta, tbam, tbai, gvcf, []]
         }
 
+    // GATK refuses to read a block-compressed VCF as intervals unless its index sits next to
+    // it, and the module has no slot for one. `dbsnp_tbi` is only ever staged, never
+    // referenced in the command, so it is used to bring the index into the work directory
+    def ch_gvcf_tbi_for_haplotypecaller = ch_tbam_gvcf
+        .map { meta, _tbam, _tbai, _gvcf, gvcf_tbi ->
+            return [meta, gvcf_tbi]
+        }
+
     GATK4_HAPLOTYPECALLER (
-        ch_input_haplotypecaller,
+        ch_tbam_gvcf_for_haplotypecaller,
         ch_genome_fasta,
         ch_genome_fai,
         ch_genome_dict,
-        [],
-        []
+        [[], []],
+        ch_gvcf_tbi_for_haplotypecaller
     )
 
-    def ch_input_genotypegvcfs = ch_tbam_gvcf
+    ch_versions = ch_versions.mix(GATK4_HAPLOTYPECALLER.out.versions)
+
+    def ch_haplotypecaller_for_genotypegvcfs = ch_tbam_gvcf
         .join(GATK4_HAPLOTYPECALLER.out.vcf)
         .join(GATK4_HAPLOTYPECALLER.out.tbi)
-        .map { meta, tbam, tbai, gvcf, gvcf_tbi, dragstr_model, vcf, tbi ->
-            return [meta, vcf, tbi, gvcf, []]
+        .map { meta, _tbam, _tbai, gvcf, gvcf_tbi, vcf, tbi ->
+            return [meta, vcf, tbi, gvcf, gvcf_tbi]
         }
 
     GATK4_GENOTYPEGVCFS (
-        ch_input_genotypegvcfs,
+        ch_haplotypecaller_for_genotypegvcfs,
         ch_genome_fasta,
         ch_genome_fai,
         ch_genome_dict,
-        [],
-        []
+        [[], []],
+        [[], []]
     )
 
-    def ch_input_bcftools_merge = ch_tbam_gvcf
+    // Merging the tumour VCF with the germline VCF puts the tumour genotype next to the
+    // germline one, so every germline variant carries the tumour allele fraction
+    def ch_genotypegvcfs_for_bcftools_merge = ch_tbam_gvcf
         .join(GATK4_GENOTYPEGVCFS.out.vcf)
         .join(GATK4_GENOTYPEGVCFS.out.tbi)
-        .map { meta, tbam, tbai, gvcf, gvcf_tbi, dragstr_model, vcf, tbi ->
+        .map { meta, _tbam, _tbai, gvcf, gvcf_tbi, vcf, tbi ->
             return [meta, [gvcf, vcf], [gvcf_tbi, tbi], []]
         }
 
-    def ch_fasta_fai = ch_genome_fasta
-        .join(ch_genome_fai)
-        .map { fasta, fai ->
-            return [fasta, fai]
+    // `.collect()` restores the value-channel semantics lost by `combine`, so that the
+    // reference can be reused by every sample
+    def ch_fasta_fai_for_bcftools_merge = ch_genome_fasta
+        .combine(ch_genome_fai)
+        .map { meta, fasta, _meta_fai, fai ->
+            return [meta, fasta, fai]
         }
+        .collect()
 
     BCFTOOLS_MERGE (
-        ch_input_bcftools_merge,
-        ch_fasta_fai,
+        ch_genotypegvcfs_for_bcftools_merge,
+        ch_fasta_fai_for_bcftools_merge
     )
 
-
-
     emit:
-    germline_taf_vcf = BCFTOOLS_MERGE.out.vcf
-    germline_taf_tbi = BCFTOOLS_MERGE.out.index
+    germline_taf_vcf = BCFTOOLS_MERGE.out.vcf   // channel: [ val(meta), path(vcf) ]
+    germline_taf_tbi = BCFTOOLS_MERGE.out.index // channel: [ val(meta), path(tbi) ]
+    versions         = ch_versions              // channel: [ path(versions.yml) ]
 
 }

--- a/subworkflows/local/annotate_germline_taf/main.nf
+++ b/subworkflows/local/annotate_germline_taf/main.nf
@@ -1,0 +1,69 @@
+include { GATK4_HAPLOTYPECALLER } from '../../../modules/nf-core/gatk4/haplotypecaller/main'
+include { GATK4_GENOTYPEGVCFS   } from '../../../modules/nf-core/gatk4/genotypegvcfs/main'
+include { BCFTOOLS_MERGE        } from '../../../modules/nf-core/bcftools/merge/main'
+
+
+workflow ANNOTATE_GERMLINE_TAF {
+    take:
+    ch_tbam_gvcf        // channel: [mandatory] input channel of tumor bam and germline vep vcf files
+    ch_genome_fasta     // channel: [mandatory] input channel of reference genome fasta file
+    ch_genome_fai       // channel: [mandatory] input channel of reference genome fai file
+    ch_genome_dict      // channel: [mandatory] input channel of reference genome dict file
+
+    main:
+
+    def ch_input_haplotypecaller = ch_tbam_gvcf
+        .map { meta, tbam, tbai, gvcf, gvcf_tbi ->
+            return [meta, tbam, tbai, gvcf, []]
+        }
+
+    GATK4_HAPLOTYPECALLER (
+        ch_input_haplotypecaller,
+        ch_genome_fasta,
+        ch_genome_fai,
+        ch_genome_dict,
+        [],
+        []
+    )
+
+    def ch_input_genotypegvcfs = ch_tbam_gvcf
+        .join(GATK4_HAPLOTYPECALLER.out.vcf)
+        .join(GATK4_HAPLOTYPECALLER.out.tbi)
+        .map { meta, tbam, tbai, gvcf, gvcf_tbi, dragstr_model, vcf, tbi ->
+            return [meta, vcf, tbi, gvcf, []]
+        }
+
+    GATK4_GENOTYPEGVCFS (
+        ch_input_genotypegvcfs,
+        ch_genome_fasta,
+        ch_genome_fai,
+        ch_genome_dict,
+        [],
+        []
+    )
+
+    def ch_input_bcftools_merge = ch_tbam_gvcf
+        .join(GATK4_GENOTYPEGVCFS.out.vcf)
+        .join(GATK4_GENOTYPEGVCFS.out.tbi)
+        .map { meta, tbam, tbai, gvcf, gvcf_tbi, dragstr_model, vcf, tbi ->
+            return [meta, [gvcf, vcf], [gvcf_tbi, tbi], []]
+        }
+
+    def ch_fasta_fai = ch_genome_fasta
+        .join(ch_genome_fai)
+        .map { fasta, fai ->
+            return [fasta, fai]
+        }
+
+    BCFTOOLS_MERGE (
+        ch_input_bcftools_merge,
+        ch_fasta_fai,
+    )
+
+
+
+    emit:
+    germline_taf_vcf = BCFTOOLS_MERGE.out.vcf
+    germline_taf_tbi = BCFTOOLS_MERGE.out.index
+
+}

--- a/subworkflows/local/annotate_germline_taf/main.nf
+++ b/subworkflows/local/annotate_germline_taf/main.nf
@@ -12,8 +12,6 @@ workflow ANNOTATE_GERMLINE_TAF {
 
     main:
 
-    def ch_versions = channel.empty()
-
     // The germline VCF is passed through the `intervals` slot so that the tumour is
     // genotyped only at the sites where a germline variant was called
     def ch_tbam_gvcf_for_haplotypecaller = ch_tbam_gvcf
@@ -37,8 +35,6 @@ workflow ANNOTATE_GERMLINE_TAF {
         [[], []],
         ch_gvcf_tbi_for_haplotypecaller
     )
-
-    ch_versions = ch_versions.mix(GATK4_HAPLOTYPECALLER.out.versions)
 
     def ch_haplotypecaller_for_genotypegvcfs = ch_tbam_gvcf
         .join(GATK4_HAPLOTYPECALLER.out.vcf)
@@ -82,6 +78,5 @@ workflow ANNOTATE_GERMLINE_TAF {
     emit:
     germline_taf_vcf = BCFTOOLS_MERGE.out.vcf   // channel: [ val(meta), path(vcf) ]
     germline_taf_tbi = BCFTOOLS_MERGE.out.index // channel: [ val(meta), path(tbi) ]
-    versions         = ch_versions              // channel: [ path(versions.yml) ]
 
 }

--- a/subworkflows/local/annotate_germline_taf/meta.yml
+++ b/subworkflows/local/annotate_germline_taf/meta.yml
@@ -1,0 +1,66 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+name: "annotate_germline_taf"
+description: Genotype the tumour BAM at the germline variant sites with GATK HaplotypeCaller and GenotypeGVCFs, then merge the result back with the germline VCF so that every germline variant carries the tumour allele fraction (TAF)
+keywords:
+  - germline
+  - tumor allele fraction
+  - taf
+  - loh
+  - haplotypecaller
+  - genotypegvcfs
+  - bcftools
+components:
+  - gatk4/haplotypecaller
+  - gatk4/genotypegvcfs
+  - bcftools/merge
+input:
+  - ch_tbam_gvcf:
+      type: file
+      description: |
+        Aligned, deduplicated BAM of the tumour sample with its index, together with the
+        germline VCF and its index. The germline VCF restricts the tumour genotyping to the
+        sites at which a germline variant was called
+        Structure: [ val(meta), path(tbam), path(tbai), path(gvcf), path(gvcf_tbi) ]
+      pattern: "*.{bam,vcf.gz}"
+  - ch_genome_fasta:
+      type: file
+      description: |
+        Reference genome FASTA
+        Structure: [ val(meta), path(fasta) ]
+      pattern: "*.{fa,fasta}"
+  - ch_genome_fai:
+      type: file
+      description: |
+        Index of the reference genome FASTA
+        Structure: [ val(meta), path(fai) ]
+      pattern: "*.fai"
+  - ch_genome_dict:
+      type: file
+      description: |
+        Sequence dictionary of the reference genome
+        Structure: [ val(meta), path(dict) ]
+      pattern: "*.dict"
+output:
+  - germline_taf_vcf:
+      type: file
+      description: |
+        Germline variants merged with the tumour genotypes, carrying the tumour allele
+        fraction for each germline variant
+        Structure: [ val(meta), path(vcf) ]
+      pattern: "*.vcf.gz"
+  - germline_taf_tbi:
+      type: file
+      description: |
+        Index of the merged VCF
+        Structure: [ val(meta), path(tbi) ]
+      pattern: "*.vcf.gz.tbi"
+  - versions:
+      type: file
+      description: |
+        File containing software versions
+        Structure: [ path(versions.yml) ]
+      pattern: "versions.yml"
+authors:
+  - "@imsarath"
+maintainers:
+  - "@imsarath"

--- a/subworkflows/local/annotate_germline_taf/tests/main.nf.test
+++ b/subworkflows/local/annotate_germline_taf/tests/main.nf.test
@@ -14,6 +14,7 @@ nextflow_workflow {
     tag "bcftools"
     tag "bcftools/merge"
 
+
     test("tumor sample with germline vcf") {
 
         when {
@@ -88,12 +89,7 @@ nextflow_workflow {
         then {
             assertAll(
                 { assert workflow.success },
-                // the empty `.vcf.gz` written by the stubs cannot be decompressed and is
-                // serialised as an absolute work path, so only the file names are asserted
-                { assert snapshot(
-                    workflow.out.germline_taf_vcf.collect { meta, vcf -> [meta, file(vcf).name] },
-                    workflow.out.germline_taf_tbi.collect { meta, tbi -> [meta, file(tbi).name] }
-                ).match() }
+                { assert snapshot(sanitizeOutput(workflow.out)).match() }
             )
         }
     }

--- a/subworkflows/local/annotate_germline_taf/tests/main.nf.test
+++ b/subworkflows/local/annotate_germline_taf/tests/main.nf.test
@@ -1,0 +1,100 @@
+nextflow_workflow {
+
+    name "Test Subworkflow ANNOTATE_GERMLINE_TAF"
+    script "../main.nf"
+    workflow "ANNOTATE_GERMLINE_TAF"
+    config "./nextflow.config"
+
+    tag "subworkflows"
+    tag "subworkflows_local"
+    tag "subworkflows/annotate_germline_taf"
+    tag "gatk4"
+    tag "gatk4/haplotypecaller"
+    tag "gatk4/genotypegvcfs"
+    tag "bcftools"
+    tag "bcftools/merge"
+
+    test("tumor sample with germline vcf") {
+
+        when {
+            workflow {
+                """
+                input[0] = channel.of([
+                    [ id:'TUMOR', case_id:'TEST', sample_name:'TUMOR', sample_type:'tumor' ],
+                    file(params.pipelines_testdata_base_path + 'testdata/bam/TUMOR_dedup.bam', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'testdata/bam/TUMOR_dedup.bai', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'testdata/vcf/NORMAL_haplotypecaller.vcf.gz', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'testdata/vcf/NORMAL_haplotypecaller.vcf.gz.tbi', checkIfExists: true)
+                ])
+                input[1] = channel.value([
+                    [ id:'genome' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.fasta', checkIfExists: true)
+                ])
+                input[2] = channel.value([
+                    [ id:'genome_fai' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.fasta.fai', checkIfExists: true)
+                ])
+                input[3] = channel.value([
+                    [ id:'genome_dict' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.dict', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    // GATK and bcftools write the tool version and the full command line into
+                    // the VCF header, so only the variant records are hashed
+                    workflow.out.germline_taf_vcf.collect { meta, vcf -> [meta, "${file(vcf).name}:${path(vcf).vcf.variantsMD5}"] },
+                    workflow.out.germline_taf_tbi.collect { meta, tbi -> [meta, file(tbi).name] }
+                ).match() }
+            )
+        }
+    }
+
+    test("tumor sample with germline vcf - stub") {
+
+        options "-stub"
+
+        when {
+            workflow {
+                """
+                input[0] = channel.of([
+                    [ id:'TUMOR', case_id:'TEST', sample_name:'TUMOR', sample_type:'tumor' ],
+                    file(params.pipelines_testdata_base_path + 'testdata/bam/TUMOR_dedup.bam', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'testdata/bam/TUMOR_dedup.bai', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'testdata/vcf/NORMAL_haplotypecaller.vcf.gz', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'testdata/vcf/NORMAL_haplotypecaller.vcf.gz.tbi', checkIfExists: true)
+                ])
+                input[1] = channel.value([
+                    [ id:'genome' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.fasta', checkIfExists: true)
+                ])
+                input[2] = channel.value([
+                    [ id:'genome_fai' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.fasta.fai', checkIfExists: true)
+                ])
+                input[3] = channel.value([
+                    [ id:'genome_dict' ],
+                    file(params.pipelines_testdata_base_path + 'reference/GRCh37/genome/human_g1k_v37_decoy.dict', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                // the empty `.vcf.gz` written by the stubs cannot be decompressed and is
+                // serialised as an absolute work path, so only the file names are asserted
+                { assert snapshot(
+                    workflow.out.germline_taf_vcf.collect { meta, vcf -> [meta, file(vcf).name] },
+                    workflow.out.germline_taf_tbi.collect { meta, tbi -> [meta, file(tbi).name] }
+                ).match() }
+            )
+        }
+    }
+}

--- a/subworkflows/local/annotate_germline_taf/tests/main.nf.test.snap
+++ b/subworkflows/local/annotate_germline_taf/tests/main.nf.test.snap
@@ -1,0 +1,64 @@
+{
+    "tumor sample with germline vcf - stub": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "TUMOR",
+                        "case_id": "TEST",
+                        "sample_name": "TUMOR",
+                        "sample_type": "tumor"
+                    },
+                    "TUMOR-all.germline.taf.vcf.gz"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TUMOR",
+                        "case_id": "TEST",
+                        "sample_name": "TUMOR",
+                        "sample_type": "tumor"
+                    },
+                    "TUMOR-all.germline.taf.vcf.gz.tbi"
+                ]
+            ]
+        ],
+        "timestamp": "2026-08-17T13:49:41.792010435",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "26.04.6"
+        }
+    },
+    "tumor sample with germline vcf": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "TUMOR",
+                        "case_id": "TEST",
+                        "sample_name": "TUMOR",
+                        "sample_type": "tumor"
+                    },
+                    "TUMOR-all.germline.taf.vcf.gz:ac0236da9d571050b8d5b037548ba90a"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TUMOR",
+                        "case_id": "TEST",
+                        "sample_name": "TUMOR",
+                        "sample_type": "tumor"
+                    },
+                    "TUMOR-all.germline.taf.vcf.gz.tbi"
+                ]
+            ]
+        ],
+        "timestamp": "2026-08-17T13:49:31.889094702",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "26.04.6"
+        }
+    }
+}

--- a/subworkflows/local/annotate_germline_taf/tests/main.nf.test.snap
+++ b/subworkflows/local/annotate_germline_taf/tests/main.nf.test.snap
@@ -1,30 +1,32 @@
 {
     "tumor sample with germline vcf - stub": {
         "content": [
-            [
-                [
-                    {
-                        "id": "TUMOR",
-                        "case_id": "TEST",
-                        "sample_name": "TUMOR",
-                        "sample_type": "tumor"
-                    },
-                    "TUMOR-all.germline.taf.vcf.gz"
+            {
+                "germline_taf_tbi": [
+                    [
+                        {
+                            "id": "TUMOR",
+                            "case_id": "TEST",
+                            "sample_name": "TUMOR",
+                            "sample_type": "tumor"
+                        },
+                        "TUMOR-all.germline.taf.vcf.gz.tbi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "germline_taf_vcf": [
+                    [
+                        {
+                            "id": "TUMOR",
+                            "case_id": "TEST",
+                            "sample_name": "TUMOR",
+                            "sample_type": "tumor"
+                        },
+                        "TUMOR-all.germline.taf.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
                 ]
-            ],
-            [
-                [
-                    {
-                        "id": "TUMOR",
-                        "case_id": "TEST",
-                        "sample_name": "TUMOR",
-                        "sample_type": "tumor"
-                    },
-                    "TUMOR-all.germline.taf.vcf.gz.tbi"
-                ]
-            ]
+            }
         ],
-        "timestamp": "2026-08-17T13:49:41.792010435",
+        "timestamp": "2026-08-20T15:57:08.402993314",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "26.04.6"

--- a/subworkflows/local/annotate_germline_taf/tests/nextflow.config
+++ b/subworkflows/local/annotate_germline_taf/tests/nextflow.config
@@ -1,0 +1,17 @@
+process {
+    withName: '.*ANNOTATE_GERMLINE_TAF:GATK4_HAPLOTYPECALLER' {
+        // GenotypeGVCFs only accepts a GVCF
+        ext.args   = { "-ERC GVCF" }
+        ext.prefix = { "${meta.sample_name}_haplotypecaller.g" }
+    }
+
+    withName: '.*ANNOTATE_GERMLINE_TAF:GATK4_GENOTYPEGVCFS' {
+        ext.prefix = { "${meta.sample_name}_genotypegvcfs" }
+    }
+
+    withName: '.*ANNOTATE_GERMLINE_TAF:BCFTOOLS_MERGE' {
+        // `--write-index=tbi` is required, otherwise BCFTOOLS_MERGE.out.index is empty
+        ext.args   = { "--output-type z --write-index=tbi" }
+        ext.prefix = { "${meta.sample_name}-all.germline.taf" }
+    }
+}


### PR DESCRIPTION
Closes #27 

### Added

- New `annotate_germline_taf` subworkflow that annotates germline variants with the tumour allele fraction: `GATK4_HAPLOTYPECALLER` genotypes the tumour BAM restricted to the germline variant sites, `GATK4_GENOTYPEGVCFS` genotypes the resulting gVCF, and `BCFTOOLS_MERGE` merges the tumour VCF with the germline VCF so each germline variant carries its tumour allele fraction.
- nf-test for the subworkflow, with snapshot.
- nf-core modules `bcftools/merge` and `gatk4/genotypegvcfs`.

