### PR TITLE
docs: update style conventions in contribution guidelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Initial release of genomic-medicine-sweden/autoseq, created with the [nf-core](h
 - [ #63 ](https://github.com/genomic-medicine-sweden/autoseq/pull/63) Updated the nf-core `fastq_create_umi_consensus_fgbio` subworkflow and its fgbio and samtools modules.
 - [ #91 ](https://github.com/genomic-medicine-sweden/autoseq/pull/91) Reference channels in `main.nf` now use `channelFromPathWithMeta`.
 - [ #95 ](https://github.com/genomic-medicine-sweden/autoseq/pull/95) Updated the contribution guidelines `docs/CONTRIBUTING.md` with new publishing strategy for pipeline outputs.
+- [ #97 ](https://github.com/genomic-medicine-sweden/autoseq/pull/97) Updated the style conventions in `docs/CONTRIBUTING.md` with sorting rules for `include` statements and `take`/`emit`/`publish` blocks, and dropped the `ch_publish` bullets left over from the previous publishing strategy.
 
 ### `Fixed`
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -307,8 +307,8 @@ Please use the following naming schemes, to make it easy to understand what is g
   val_genome         // string:  [optional]  genome assembly (e.g. "GRCh38")
 
   emit:
-  vcf  = ch_vcf             // channel: [ val(meta), path(vcf) ]
-  tbi  = ch_tbi.mix(ch_csi) // channel: [ val(meta), path(tbi_index) ]
+  somatic_vcf  = ch_vcf             // channel: [ val(meta), path(vcf) ]
+  index        = ch_tbi.mix(ch_csi) // channel: [ val(meta), path(index) ]
   ```
 
 - Use `ch_* = <...>` whenever possible. Avoid using the `.set {ch_*}` operator to create new channels.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -287,20 +287,28 @@ Please use the following naming schemes, to make it easy to understand what is g
 
 ### Style
 
+- Sort `include` statements alphabetically by the name inside the brackets. Right-pad each name with spaces so all closing `}` align to the same column (the longest name in the block sets the width):
+
+  ```groovy
+  include { BCFTOOLS_VIEW as FILTER_VCF } from '../../../modules/nf-core/bcftools/view/main'
+  include { TIDDIT_COV                  } from '../../../modules/nf-core/tiddit/cov/main'
+  include { VCF2CYTOSURE                } from '../../../modules/nf-core/vcf2cytosure/main'
+  ```
+
+- Sort items in the `take`, `emit` and `publish` blocks, alphabetically (see example below).
+
 - Both `take:` and `emit:` block entries require an inline type comment. Use `name // type: [mandatory|optional] description` for `take:` and `name = value // channel: [type description]` for `emit:`. Always include the comment — never leave an entry uncommented.
 
   ```groovy
   take:
-      ch_vcf                // channel: [mandatory] [ val(meta), path(vcf) ]
-      ch_reduced_penetrance // channel: [optional]  [ path(penetrance) ]
-      val_aligner           // string:  [mandatory] aligner name (bwa/bwamem2/bwameme)
-      process_with_sort     // Boolean
+  ch_vep_cache       // channel: [optional]  [path(vep_cache)]
+  ch_vep_extra_files // channel: [optional]  [path(plugin_file1), path(plugin_file2), ...]
+  val_cadd_resources // string:  [optional]  path to CADD resources directory
+  val_genome         // string:  [optional]  genome assembly (e.g. "GRCh38")
 
   emit:
-      vcf     = ch_vcf      // channel: [ val(meta), path(vcf) ]
-      publish = ch_publish  // channel: [ val(destination), val(value) ]
+  vcf   = ch_vcf             // channel: [ val(meta), path(vcf) ]
+  index = ch_tbi.mix(ch_csi) // channel: [ val(meta), path(index) ]
   ```
 
-- Avoid using the `.set {ch_*}` operator to create new channels. Use `ch_* = <...>` whenever possible.
-- Intermediate publish channels in `workflows/autoseq.nf` follow the `ch_<subworkflow_name>_publish` naming convention and are assigned immediately after the subworkflow call, not inline in the emit block.
-- Initialize all `ch_*_publish` variables at the top of the `main:` block alongside `ch_multiqc_files`.
+- Use `ch_* = <...>` whenever possible. Avoid using the `.set {ch_*}` operator to create new channels.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -307,8 +307,8 @@ Please use the following naming schemes, to make it easy to understand what is g
   val_genome         // string:  [optional]  genome assembly (e.g. "GRCh38")
 
   emit:
-  vcf   = ch_vcf             // channel: [ val(meta), path(vcf) ]
-  index = ch_tbi.mix(ch_csi) // channel: [ val(meta), path(index) ]
+  vcf  = ch_vcf             // channel: [ val(meta), path(vcf) ]
+  tbi  = ch_tbi.mix(ch_csi) // channel: [ val(meta), path(tbi_index) ]
   ```
 
 - Use `ch_* = <...>` whenever possible. Avoid using the `.set {ch_*}` operator to create new channels.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -308,7 +308,7 @@ Please use the following naming schemes, to make it easy to understand what is g
 
   emit:
   somatic_vcf  = ch_vcf             // channel: [ val(meta), path(vcf) ]
-  index        = ch_tbi.mix(ch_csi) // channel: [ val(meta), path(index) ]
+  tbi          = ch_tbi.mix(ch_csi) // channel: [ val(meta), path(tbi) ]
   ```
 
 - Use `ch_* = <...>` whenever possible. Avoid using the `.set {ch_*}` operator to create new channels.


### PR DESCRIPTION
### Changed

- Added style rules for sorting `include` statements (alphabetical, right-padded so the closing braces align) and for sorting items in the `take`, `emit` and `publish` blocks.
- Refreshed the `take:` / `emit:` example to match the current formatting.

### Removed

- The `ch_<subworkflow_name>_publish` naming and `ch_*_publish` initialization bullets, and `publish = ch_publish` from the emit example — leftovers from the previous publishing strategy replaced in #95.