### PR TITLE
feat: add prepare_hetsnps_for_frankenplot module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Initial release of genomic-medicine-sweden/autoseq, created with the [nf-core](h
 - [ #90 ](https://github.com/genomic-medicine-sweden/autoseq/pull/90) Added nf-test and `meta.yml` for the `CALL_SOMATIC_SNVS` subworkflow covering a paired tumor/normal case and a stub case.
 - [ #91 ](https://github.com/genomic-medicine-sweden/autoseq/pull/91) Added the `channelFromPathWithMeta` helper to build `[[id:...], file]` reference channels from a path, or `channel.empty()` when the path is null.
 - [ #96 ](https://github.com/genomic-medicine-sweden/autoseq/pull/96) Added the `ANNOTATE_GERMLINE_TAF` subworkflow to annotate germline variants with the tumor allele fraction, with nf-test and `meta.yml`.
+- [ #103 ](https://github.com/genomic-medicine-sweden/autoseq/pull/103) Added the `PREPARE_HETSNPS_FOR_FRANKENPLOT` local module and its `prepare_hetsnps_for_frankenplot.py` script, which filters a germline VCF to heterozygous SNVs and appends a sample column with BAM-derived `GT`, `DP` and `AD` for Frankenplot BAF plotting, with nf-test and `meta.yml`.
 
 ### `Changed`
 

--- a/bin/prepare_hetsnps_for_frankenplot.py
+++ b/bin/prepare_hetsnps_for_frankenplot.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python
+"""het_snps_with_bam_afs.py
+
+Quality-filter a VCF, keep only heterozygous simple SNVs, and add a new sample column
+carrying DP and AD (ref,alt observations) read from a BAM pileup at each site.
+
+Usage example:
+    het_snps_with_bam_afs.py -i germline.vcf.gz -b tumor.bam -o out.vcf.gz \\
+        --samplename TUMOR --filter-hom --no-filtered --site-quality 5
+
+VCF and BAM parsing use pysam; the bgzipped output and its tabix index are written by this
+script.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from collections.abc import Callable, Generator, Sequence
+from contextlib import contextmanager
+from typing import Protocol
+
+import pysam
+from pysam import AlignmentFile, BGZFile, VariantFile, VariantHeader, VariantRecord
+
+__version__ = "1.0.0"
+
+logger = logging.getLogger("het_snps_with_bam_afs")
+
+MISSING = "."
+NOCALL_GT = "./."
+HOM_GENOTYPES = frozenset({"0/0", "1/1"})
+SITE_QUALITY_FILTER_DESCRIPTION = "Filter low quality sites"
+
+# FORMAT fields written for the added sample; used as fallback header definitions when the
+# input header does not already define them.
+FORMAT_DEFINITIONS: dict[str, str] = {
+    "GT": '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+    "DP": '##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth">',
+    "AD": (
+        '##FORMAT=<ID=AD,Number=R,Type=Integer,Description='
+        '"Allelic depths for the ref and alt alleles in the order listed">'
+    ),
+}
+
+
+class _SampleLike(Protocol):
+    """Minimal view of a pysam ``VariantRecordSample``."""
+
+    allele_indices: tuple[int | None, ...] | None
+    phased: bool
+
+
+def genotype_string(sample: _SampleLike) -> str:
+    """Render a genotype the way PyVCF's ``call.data.GT`` did, e.g. ``0/1`` or ``0|1``."""
+    indices = sample.allele_indices
+    if not indices:
+        return MISSING
+    separator = "|" if sample.phased else "/"
+    return separator.join(MISSING if index is None else str(index) for index in indices)
+
+
+def site_quality_filter_id(site_quality: int) -> str:
+    """FILTER id for a quality threshold, e.g. ``sq5`` (PyVCF's naming)."""
+    return f"sq{site_quality}"
+
+
+def is_low_quality(record: VariantRecord, site_quality: int) -> bool:
+    """True when QUAL is below the threshold.
+
+    A missing QUAL ('.') passes: PyVCF on Python 2 compared None < threshold and returned
+    None, which its filter loop read as "not filtered".
+    """
+    return record.qual is not None and float(record.qual) < site_quality
+
+
+def is_snv(record: VariantRecord) -> bool:
+    """True for a single biallelic 1bp REF/ALT swap; indels and multi-allelics are not."""
+    alts = record.alts or ()
+    return len(record.ref or "") == 1 and len(alts) == 1 and len(alts[0]) == 1
+
+
+def pileup_bases(bam: AlignmentFile, contig: str, position: int) -> list[str]:
+    """Collect the read bases aligned to a 1-based position, skipping deletions and skips.
+
+    pysam's pileup defaults apply, as they did in vcf_add_sample.py: reads flagged unmapped,
+    secondary, QC-fail or duplicate are skipped, bases below quality 13 are ignored, and
+    overlapping mates are counted once.
+    """
+    bases: list[str] = []
+    for column in bam.pileup(contig, position - 1, position, truncate=True):
+        for read in column.pileups:
+            if read.is_del or read.is_refskip:
+                continue
+            sequence = read.alignment.query_sequence
+            if sequence is None or read.query_position is None:
+                continue
+            bases.append(sequence[read.query_position])
+    bases.sort()
+    return bases
+
+
+VcfTextWriter = Callable[[str], object]
+
+
+@contextmanager
+def open_output(output: str) -> Generator[VcfTextWriter, None, None]:
+    """Yield a text writer for ``-`` (stdout), ``*.vcf`` (plain) or ``*.gz`` (BGZF)."""
+    if output == "-":
+        yield sys.stdout.write
+        return
+    if output.endswith(".gz"):
+        bgzf = BGZFile(output, "wb", None)  # third arg is the (unused) index path
+        try:
+            yield lambda text: bgzf.write(text.encode("utf-8"))
+        finally:
+            bgzf.close()
+        return
+    with open(output, "w", encoding="utf-8") as plain:
+        yield plain.write
+
+
+def build_output_header(template: VariantHeader, samplename: str) -> VariantHeader:
+    """Copy the input header, declare the FORMAT keys written here, and add the sample."""
+    header = template.copy()
+    for key, definition in FORMAT_DEFINITIONS.items():
+        if key not in header.formats:
+            header.add_line(definition)
+    header.add_sample(samplename)
+    return header
+
+
+def render_record(record: VariantRecord, new_sample: dict[str, str]) -> str:
+    """Render a VCF line with an extra sample column appended.
+
+    pysam cannot append a sample to a record parsed against an existing header, so the line
+    is rendered by htslib and the new column is appended textually. FORMAT keys missing from
+    the record (typically DP or AD) are added, and the existing samples padded with '.'.
+    """
+    fields = str(record).rstrip("\n").split("\t")
+    fixed, format_column, samples = fields[:8], fields[8:9], fields[9:]
+
+    keys = format_column[0].split(":") if format_column else []
+    if not keys:
+        keys = ["GT"]
+        samples = [NOCALL_GT for _ in samples]
+
+    for key in new_sample:
+        if key not in keys:
+            keys.append(key)
+            samples = [f"{sample}:{MISSING}" for sample in samples]
+
+    added = ":".join(new_sample.get(key, MISSING) for key in keys)
+    return "\t".join([*fixed, ":".join(keys), *samples, added]) + "\n"
+
+
+def process(
+    vcf_path: str,
+    bam_path: str,
+    output: str,
+    samplename: str,
+    site_quality: int | None,
+    filter_hom: bool,
+    drop_filtered: bool,
+) -> int:
+    """Filter, subset to het SNVs, add BAM-derived depths, and write the output VCF."""
+    written = 0
+
+    with VariantFile(vcf_path) as in_vcf, AlignmentFile(bam_path, "rb") as bam:
+        if samplename in in_vcf.header.samples:
+            raise ValueError(f"Sample '{samplename}' is already present in {vcf_path}")
+
+        # The FILTER id has to be declared on the header the records are attached to:
+        # htslib rejects record.filter.add() for an id its own header does not know.
+        if site_quality is not None:
+            in_vcf.header.filters.add(
+                site_quality_filter_id(site_quality),
+                None,
+                None,
+                SITE_QUALITY_FILTER_DESCRIPTION,
+            )
+        header = build_output_header(in_vcf.header, samplename)
+
+        with open_output(output) as writer:
+            writer(str(header))
+            for record in in_vcf:
+                if site_quality is not None and is_low_quality(record, site_quality):
+                    if drop_filtered:
+                        continue
+                    record.filter.add(site_quality_filter_id(site_quality))
+                # PyVCF only stamped PASS when filtered records were kept in the output.
+                # Pre-existing FILTER values from the input are left untouched either way.
+                if not drop_filtered and not list(record.filter):
+                    record.filter.add("PASS")
+
+                calls = [genotype_string(sample) for sample in record.samples.values()]
+                if filter_hom and any(call in HOM_GENOTYPES for call in calls):
+                    continue
+
+                if not is_snv(record):
+                    continue
+
+                alt = (record.alts or ("",))[0]
+                bases = pileup_bases(bam, record.contig, record.pos)
+                logger.debug(
+                    "pileup at %s:%d %s/%s = %s",
+                    record.contig,
+                    record.pos,
+                    record.ref,
+                    alt,
+                    "".join(bases),
+                )
+                depth = len(bases)
+                ref_obs = sum(1 for base in bases if base == record.ref)
+                alt_obs = sum(1 for base in bases if base == alt)
+                writer(
+                    render_record(
+                        record,
+                        {"GT": NOCALL_GT, "DP": str(depth), "AD": f"{ref_obs},{alt_obs}"},
+                    )
+                )
+                written += 1
+
+    logger.info("Wrote %d variant(s) to %s", written, output)
+    if output != "-" and output.endswith(".gz"):
+        pysam.tabix_index(output, preset="vcf", force=True)
+        logger.info("Indexed %s.tbi", output)
+    return written
+
+
+def setup_logging(loglevel: str) -> None:
+    """Configure stderr logging at the requested level.
+
+    An unknown level name raises ValueError out of the logging module itself.
+    """
+    logging.basicConfig(
+        level=loglevel.upper(),
+        stream=sys.stderr,
+        format="%(levelname)s %(asctime)s %(funcName)s - %(message)s",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command line parser."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Filter a VCF, keep heterozygous simple SNVs, and add a sample column with "
+            "DP and AD taken from a BAM pileup. Writes .vcf.gz plus its tabix index."
+        ),
+        epilog="Compression is single threaded (htslib BGZF).",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("-i", "--input", required=True, help="Input VCF/BCF ('-' for stdin)")
+    parser.add_argument("-b", "--bam", required=True, help="Indexed BAM for the sample to add")
+    parser.add_argument(
+        "-o",
+        "--output",
+        required=True,
+        help="Output VCF; '.gz' writes BGZF and a tabix index, '-' writes to stdout",
+    )
+    parser.add_argument("--samplename", required=True, help="Name of the sample to add")
+    parser.add_argument(
+        "--site-quality",
+        # int, like PyVCF, so the FILTER id reads 'sq5' rather than 'sq5.0'.
+        type=int,
+        default=None,
+        metavar="QUAL",
+        help="Filter sites with QUAL below this value; omit to disable quality filtering",
+    )
+    parser.add_argument(
+        "--filter-hom",
+        "--filter_hom",
+        dest="filter_hom",
+        action="store_true",
+        help="Drop variants that are homozygous (0/0 or 1/1) in any input sample",
+    )
+    parser.add_argument(
+        "--no-filtered",
+        action="store_true",
+        help="Output only sites passing the filter, instead of tagging them in FILTER",
+    )
+    parser.add_argument("--loglevel", default="INFO", help="Level of logging")
+    parser.add_argument("-v", "--version", action="version", version=f"%(prog)s {__version__}")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Parse arguments and run the conversion."""
+    args = build_parser().parse_args(argv)
+    setup_logging(args.loglevel)
+    logger.info("Started log with loglevel %s", args.loglevel)
+
+    process(
+        vcf_path=args.input,
+        bam_path=args.bam,
+        output=args.output,
+        samplename=args.samplename,
+        site_quality=args.site_quality,
+        filter_hom=args.filter_hom,
+        drop_filtered=args.no_filtered,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/prepare_hetsnps_for_frankenplot.py
+++ b/bin/prepare_hetsnps_for_frankenplot.py
@@ -1,36 +1,41 @@
 #!/usr/bin/env python
-"""het_snps_with_bam_afs.py
+"""prepare_hetsnps_for_frankenplot.py
 
 Quality-filter a VCF, keep only heterozygous simple SNVs, and add a new sample column
 carrying DP and AD (ref,alt observations) read from a BAM pileup at each site.
 
 Usage example:
-    het_snps_with_bam_afs.py -i germline.vcf.gz -b tumor.bam -o out.vcf.gz \\
+    prepare_hetsnps_for_frankenplot.py -i germline.vcf.gz -b tumor.bam -o out.vcf.gz \\
         --samplename TUMOR --filter-hom --no-filtered --site-quality 5
 
 VCF and BAM parsing use pysam; the bgzipped output and its tabix index are written by this
 script.
 """
 
-from __future__ import annotations
-
 import argparse
 import logging
 import sys
+from collections import Counter
 from collections.abc import Callable, Generator, Sequence
 from contextlib import contextmanager
-from typing import Protocol
 
 import pysam
-from pysam import AlignmentFile, BGZFile, VariantFile, VariantHeader, VariantRecord
+from pysam import (
+    AlignmentFile,
+    BGZFile,
+    VariantFile,
+    VariantHeader,
+    VariantRecord,
+    VariantRecordSample,
+)
 
 __version__ = "1.0.0"
 
-logger = logging.getLogger("het_snps_with_bam_afs")
+logger = logging.getLogger("prepare_hetsnps_for_frankenplot")
 
 MISSING = "."
 NOCALL_GT = "./."
-HOM_GENOTYPES = frozenset({"0/0", "1/1"})
+DEFAULT_MAX_DEPTH = 8000
 SITE_QUALITY_FILTER_DESCRIPTION = "Filter low quality sites"
 
 # FORMAT fields written for the added sample; used as fallback header definitions when the
@@ -45,20 +50,10 @@ FORMAT_DEFINITIONS: dict[str, str] = {
 }
 
 
-class _SampleLike(Protocol):
-    """Minimal view of a pysam ``VariantRecordSample``."""
-
-    allele_indices: tuple[int | None, ...] | None
-    phased: bool
-
-
-def genotype_string(sample: _SampleLike) -> str:
-    """Render a genotype the way PyVCF's ``call.data.GT`` did, e.g. ``0/1`` or ``0|1``."""
+def is_homozygous(sample: VariantRecordSample) -> bool:
+    """True when every called allele is the same, e.g. 0/0, 1/1 or the phased 0|0."""
     indices = sample.allele_indices
-    if not indices:
-        return MISSING
-    separator = "|" if sample.phased else "/"
-    return separator.join(MISSING if index is None else str(index) for index in indices)
+    return bool(indices) and None not in indices and len(set(indices)) == 1
 
 
 def site_quality_filter_id(site_quality: int) -> str:
@@ -81,15 +76,16 @@ def is_snv(record: VariantRecord) -> bool:
     return len(record.ref or "") == 1 and len(alts) == 1 and len(alts[0]) == 1
 
 
-def pileup_bases(bam: AlignmentFile, contig: str, position: int) -> list[str]:
+def pileup_bases(bam: AlignmentFile, contig: str, position: int, max_depth: int) -> list[str]:
     """Collect the read bases aligned to a 1-based position, skipping deletions and skips.
 
     pysam's pileup defaults apply, as they did in vcf_add_sample.py: reads flagged unmapped,
     secondary, QC-fail or duplicate are skipped, bases below quality 13 are ignored, and
-    overlapping mates are counted once.
+    overlapping mates are counted once. ``max_depth`` caps how many reads are piled up at a
+    site; deep panels need it raised above the pysam default.
     """
     bases: list[str] = []
-    for column in bam.pileup(contig, position - 1, position, truncate=True):
+    for column in bam.pileup(contig, position - 1, position, truncate=True, max_depth=max_depth):
         for read in column.pileups:
             if read.is_del or read.is_refskip:
                 continue
@@ -97,7 +93,6 @@ def pileup_bases(bam: AlignmentFile, contig: str, position: int) -> list[str]:
             if sequence is None or read.query_position is None:
                 continue
             bases.append(sequence[read.query_position])
-    bases.sort()
     return bases
 
 
@@ -111,7 +106,7 @@ def open_output(output: str) -> Generator[VcfTextWriter, None, None]:
         yield sys.stdout.write
         return
     if output.endswith(".gz"):
-        bgzf = BGZFile(output, "wb", None)  # third arg is the (unused) index path
+        bgzf = BGZFile(output, "wb")
         try:
             yield lambda text: bgzf.write(text.encode("utf-8"))
         finally:
@@ -139,12 +134,9 @@ def render_record(record: VariantRecord, new_sample: dict[str, str]) -> str:
     the record (typically DP or AD) are added, and the existing samples padded with '.'.
     """
     fields = str(record).rstrip("\n").split("\t")
-    fixed, format_column, samples = fields[:8], fields[8:9], fields[9:]
-
-    keys = format_column[0].split(":") if format_column else []
-    if not keys:
-        keys = ["GT"]
-        samples = [NOCALL_GT for _ in samples]
+    fixed, rest = fields[:8], fields[8:]
+    keys = rest[0].split(":") if rest else ["GT"]
+    samples = rest[1:]
 
     for key in new_sample:
         if key not in keys:
@@ -163,6 +155,7 @@ def process(
     site_quality: int | None,
     filter_hom: bool,
     drop_filtered: bool,
+    max_depth: int,
 ) -> int:
     """Filter, subset to het SNVs, add BAM-derived depths, and write the output VCF."""
     written = 0
@@ -173,13 +166,9 @@ def process(
 
         # The FILTER id has to be declared on the header the records are attached to:
         # htslib rejects record.filter.add() for an id its own header does not know.
-        if site_quality is not None:
-            in_vcf.header.filters.add(
-                site_quality_filter_id(site_quality),
-                None,
-                None,
-                SITE_QUALITY_FILTER_DESCRIPTION,
-            )
+        filter_id = site_quality_filter_id(site_quality) if site_quality is not None else None
+        if filter_id is not None:
+            in_vcf.header.filters.add(filter_id, None, None, SITE_QUALITY_FILTER_DESCRIPTION)
         header = build_output_header(in_vcf.header, samplename)
 
         with open_output(output) as writer:
@@ -188,42 +177,43 @@ def process(
                 if site_quality is not None and is_low_quality(record, site_quality):
                     if drop_filtered:
                         continue
-                    record.filter.add(site_quality_filter_id(site_quality))
+                    record.filter.add(filter_id)
                 # PyVCF only stamped PASS when filtered records were kept in the output.
                 # Pre-existing FILTER values from the input are left untouched either way.
                 if not drop_filtered and not list(record.filter):
                     record.filter.add("PASS")
 
-                calls = [genotype_string(sample) for sample in record.samples.values()]
-                if filter_hom and any(call in HOM_GENOTYPES for call in calls):
+                if filter_hom and any(is_homozygous(call) for call in record.samples.values()):
                     continue
 
                 if not is_snv(record):
                     continue
 
-                alt = (record.alts or ("",))[0]
-                bases = pileup_bases(bam, record.contig, record.pos)
-                logger.debug(
-                    "pileup at %s:%d %s/%s = %s",
-                    record.contig,
-                    record.pos,
-                    record.ref,
-                    alt,
-                    "".join(bases),
-                )
-                depth = len(bases)
-                ref_obs = sum(1 for base in bases if base == record.ref)
-                alt_obs = sum(1 for base in bases if base == alt)
+                alt = record.alts[0]
+                counts = Counter(pileup_bases(bam, record.contig, record.pos, max_depth))
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(
+                        "pileup at %s:%d %s/%s = %s",
+                        record.contig,
+                        record.pos,
+                        record.ref,
+                        alt,
+                        "".join(base * count for base, count in sorted(counts.items())),
+                    )
                 writer(
                     render_record(
                         record,
-                        {"GT": NOCALL_GT, "DP": str(depth), "AD": f"{ref_obs},{alt_obs}"},
+                        {
+                            "GT": NOCALL_GT,
+                            "DP": str(sum(counts.values())),
+                            "AD": f"{counts[record.ref]},{counts[alt]}",
+                        },
                     )
                 )
                 written += 1
 
     logger.info("Wrote %d variant(s) to %s", written, output)
-    if output != "-" and output.endswith(".gz"):
+    if output.endswith(".gz"):
         pysam.tabix_index(output, preset="vcf", force=True)
         logger.info("Indexed %s.tbi", output)
     return written
@@ -269,15 +259,20 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--filter-hom",
-        "--filter_hom",
-        dest="filter_hom",
         action="store_true",
-        help="Drop variants that are homozygous (0/0 or 1/1) in any input sample",
+        help="Drop variants that are homozygous in any input sample",
     )
     parser.add_argument(
         "--no-filtered",
         action="store_true",
         help="Output only sites passing the filter, instead of tagging them in FILTER",
+    )
+    parser.add_argument(
+        "--max-depth",
+        type=int,
+        default=DEFAULT_MAX_DEPTH,
+        metavar="N",
+        help="Maximum number of reads piled up at a site; raise it for deep panels",
     )
     parser.add_argument("--loglevel", default="INFO", help="Level of logging")
     parser.add_argument("-v", "--version", action="version", version=f"%(prog)s {__version__}")
@@ -298,6 +293,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         site_quality=args.site_quality,
         filter_hom=args.filter_hom,
         drop_filtered=args.no_filtered,
+        max_depth=args.max_depth,
     )
     return 0
 

--- a/bin/prepare_hetsnps_for_frankenplot.py
+++ b/bin/prepare_hetsnps_for_frankenplot.py
@@ -262,7 +262,6 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--samplename", required=True, help="Name of the sample to add")
     parser.add_argument(
         "--site-quality",
-        # int, like PyVCF, so the FILTER id reads 'sq5' rather than 'sq5.0'.
         type=int,
         default=None,
         metavar="QUAL",

--- a/modules/local/prepare_hetsnps_for_frankenplot/environment.yml
+++ b/modules/local/prepare_hetsnps_for_frankenplot/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::pysam=0.24.0

--- a/modules/local/prepare_hetsnps_for_frankenplot/main.nf
+++ b/modules/local/prepare_hetsnps_for_frankenplot/main.nf
@@ -4,8 +4,8 @@ process PREPARE_HETSNPS_FOR_FRANKENPLOT {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/pysam:0.24.0--py312hf5ad864_1' :
-        'biocontainers/pysam:0.24.0--py312hf5ad864_1' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/be/be0fed5a63cca4fd0f70dcf67ef383c8ea1a305697bda9103e7387ca96e27967/data' :
+        'community.wave.seqera.io/library/pysam_tabix_gzip:8124a02a31e03aad' }"
 
     input:
     tuple val(meta), path(vcf), path(tbi), path(bam), path(bai)
@@ -22,8 +22,6 @@ process PREPARE_HETSNPS_FOR_FRANKENPLOT {
     def args   = task.ext.args   ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
 
-    // The added sample defaults to the meta id. `$args` is appended last, so a `--samplename`
-    // set through `ext.args` is the one argparse keeps.
     """
     prepare_hetsnps_for_frankenplot.py \\
         --input ${vcf} \\
@@ -37,7 +35,7 @@ process PREPARE_HETSNPS_FOR_FRANKENPLOT {
     def prefix = task.ext.prefix ?: "${meta.id}"
 
     """
-    touch ${prefix}.hetsnps.vcf.gz
+    echo "" | gzip > ${prefix}.hetsnps.vcf.gz
     touch ${prefix}.hetsnps.vcf.gz.tbi
     """
 }

--- a/modules/local/prepare_hetsnps_for_frankenplot/main.nf
+++ b/modules/local/prepare_hetsnps_for_frankenplot/main.nf
@@ -1,0 +1,43 @@
+process PREPARE_HETSNPS_FOR_FRANKENPLOT {
+    tag "${meta.id}"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/pysam:0.24.0--py312hf5ad864_1' :
+        'biocontainers/pysam:0.24.0--py312hf5ad864_1' }"
+
+    input:
+    tuple val(meta), path(vcf), path(tbi), path(bam), path(bai)
+
+    output:
+    tuple val(meta), path("*.hetsnps.vcf.gz")    , emit: vcf
+    tuple val(meta), path("*.hetsnps.vcf.gz.tbi"), emit: tbi
+    tuple val("${task.process}"), val('prepare_hetsnps_for_frankenplot'), eval("prepare_hetsnps_for_frankenplot.py --version"), topic: versions, emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args   = task.ext.args   ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    // The added sample defaults to the meta id. `$args` is appended last, so a `--samplename`
+    // set through `ext.args` is the one argparse keeps.
+    """
+    prepare_hetsnps_for_frankenplot.py \\
+        --input ${vcf} \\
+        --bam ${bam} \\
+        --output ${prefix}.hetsnps.vcf.gz \\
+        --samplename ${meta.id} \\
+        ${args}
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    """
+    touch ${prefix}.hetsnps.vcf.gz
+    touch ${prefix}.hetsnps.vcf.gz.tbi
+    """
+}

--- a/modules/local/prepare_hetsnps_for_frankenplot/meta.yml
+++ b/modules/local/prepare_hetsnps_for_frankenplot/meta.yml
@@ -1,0 +1,88 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "prepare_hetsnps_for_frankenplot"
+description: Quality-filters a germline VCF down to heterozygous simple SNVs and appends
+  a sample column carrying GT, DP and AD read from a tumour BAM pileup, so that B-allele
+  frequencies can be plotted in a Frankenplot.
+keywords:
+  - baf
+  - frankenplot
+  - germline
+  - heterozygous
+  - snp
+  - vcf
+tools:
+  - prepare_hetsnps_for_frankenplot:
+      description: Standalone python script that filters a VCF to heterozygous SNVs and adds BAM-derived allelic depths as a new sample column
+      homepage: "https://www.python.org/"
+      documentation: "https://docs.python.org/3/"
+  - pysam:
+      description: Python module for reading and manipulating SAM/BAM/VCF files
+      homepage: "https://pysam.readthedocs.io/en/latest/"
+      documentation: "https://pysam.readthedocs.io/en/latest/api.html"
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'TUMOR', case_id:'TEST', sample_name:'TUMOR', sample_type:'tumor' ]`
+  - vcf:
+      type: file
+      description: Germline VCF to filter for heterozygous SNVs
+      pattern: "*.{vcf,vcf.gz}"
+      ontologies:
+        - edam: "http://edamontology.org/format_3016" # VCF
+  - tbi:
+      type: file
+      description: Tabix index for the germline VCF
+      pattern: "*.{tbi,csi}"
+  - bam:
+      type: file
+      description: Tumour BAM to pile up at each retained site
+      pattern: "*.bam"
+      ontologies:
+        - edam: "http://edamontology.org/format_2572" # BAM
+  - bai:
+      type: file
+      description: Index for the tumour BAM
+      pattern: "*.{bai,csi}"
+
+output:
+  vcf:
+    - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'TUMOR', case_id:'TEST', sample_name:'TUMOR', sample_type:'tumor' ]`
+    - "*.hetsnps.vcf.gz":
+        type: file
+        description: Bgzipped heterozygous SNP VCF with the tumour sample column appended
+        pattern: "*.hetsnps.vcf.gz"
+        ontologies:
+          - edam: "http://edamontology.org/format_3016" # VCF
+  tbi:
+    - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'TUMOR', case_id:'TEST', sample_name:'TUMOR', sample_type:'tumor' ]`
+    - "*.hetsnps.vcf.gz.tbi":
+        type: file
+        description: Tabix index for the heterozygous SNP VCF
+        pattern: "*.hetsnps.vcf.gz.tbi"
+
+topics:
+  versions:
+    - ${task.process}:
+        type: string
+        description: The name of the process
+    - prepare_hetsnps_for_frankenplot:
+        type: string
+        description: The name of the tool
+    - prepare_hetsnps_for_frankenplot.py --version:
+        type: eval
+        description: The expression to obtain the version of the tool
+
+authors:
+  - "@imsarath"
+maintainers:
+  - "@imsarath"

--- a/modules/local/prepare_hetsnps_for_frankenplot/tests/main.nf.test
+++ b/modules/local/prepare_hetsnps_for_frankenplot/tests/main.nf.test
@@ -1,0 +1,117 @@
+nextflow_process {
+
+    name "Test Process PREPARE_HETSNPS_FOR_FRANKENPLOT"
+    script "../main.nf"
+    process "PREPARE_HETSNPS_FOR_FRANKENPLOT"
+    config "./nextflow.config"
+
+    tag "modules"
+    tag "modules_local"
+    tag "prepare_hetsnps_for_frankenplot"
+
+
+    test("germline vcf with tumor bam") {
+
+        when {
+            params {
+                prepare_hetsnps_for_frankenplot_args = "--site-quality 5 --filter-hom --no-filtered"
+            }
+
+            process {
+                """
+                input[0] = channel.of([
+                    [ id:'TUMOR', case_id:'TEST', sample_name:'TUMOR', sample_type:'tumor' ],
+                    file(params.pipelines_testdata_base_path + 'testdata/vcf/NORMAL_haplotypecaller.vcf.gz', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'testdata/vcf/NORMAL_haplotypecaller.vcf.gz.tbi', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'testdata/bam/TUMOR_dedup.bam', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'testdata/bam/TUMOR_dedup.bai', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    // GATK writes the tool version and the full command line into the VCF
+                    // header, so only the variant records are hashed
+                    process.out.vcf.collect { meta, vcf -> [meta, "${file(vcf).name}:${path(vcf).vcf.variantsMD5}"] },
+                    process.out.tbi.collect { meta, tbi -> [meta, file(tbi).name] },
+                    process.out.versions
+                ).match() }
+            )
+        }
+    }
+
+    test("germline vcf with tumor bam - filtered sites kept") {
+
+        when {
+            params {
+                // Without `--no-filtered` the low quality sites stay in the output, tagged
+                // in FILTER instead of being dropped
+                prepare_hetsnps_for_frankenplot_args = "--site-quality 100 --filter-hom"
+            }
+
+            process {
+                """
+                input[0] = channel.of([
+                    [ id:'TUMOR', case_id:'TEST', sample_name:'TUMOR', sample_type:'tumor' ],
+                    file(params.pipelines_testdata_base_path + 'testdata/vcf/NORMAL_haplotypecaller.vcf.gz', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'testdata/vcf/NORMAL_haplotypecaller.vcf.gz.tbi', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'testdata/bam/TUMOR_dedup.bam', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'testdata/bam/TUMOR_dedup.bai', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.vcf.collect { meta, vcf -> [meta, "${file(vcf).name}:${path(vcf).vcf.variantsMD5}"] },
+                    process.out.tbi.collect { meta, tbi -> [meta, file(tbi).name] },
+                    process.out.versions
+                ).match() }
+            )
+        }
+    }
+
+    test("germline vcf with tumor bam - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                prepare_hetsnps_for_frankenplot_args = "--site-quality 5 --filter-hom --no-filtered"
+            }
+
+            process {
+                """
+                input[0] = channel.of([
+                    [ id:'TUMOR', case_id:'TEST', sample_name:'TUMOR', sample_type:'tumor' ],
+                    file(params.pipelines_testdata_base_path + 'testdata/vcf/NORMAL_haplotypecaller.vcf.gz', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'testdata/vcf/NORMAL_haplotypecaller.vcf.gz.tbi', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'testdata/bam/TUMOR_dedup.bam', checkIfExists: true),
+                    file(params.pipelines_testdata_base_path + 'testdata/bam/TUMOR_dedup.bai', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                // the empty `.vcf.gz` written by the stub cannot be decompressed and is
+                // serialised as an absolute work path, so only the file names are asserted
+                { assert snapshot(
+                    process.out.vcf.collect { meta, vcf -> [meta, file(vcf).name] },
+                    process.out.tbi.collect { meta, tbi -> [meta, file(tbi).name] },
+                    process.out.versions
+                ).match() }
+            )
+        }
+    }
+
+}

--- a/modules/local/prepare_hetsnps_for_frankenplot/tests/main.nf.test
+++ b/modules/local/prepare_hetsnps_for_frankenplot/tests/main.nf.test
@@ -34,42 +34,6 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                    // GATK writes the tool version and the full command line into the VCF
-                    // header, so only the variant records are hashed
-                    process.out.vcf.collect { meta, vcf -> [meta, "${file(vcf).name}:${path(vcf).vcf.variantsMD5}"] },
-                    process.out.tbi.collect { meta, tbi -> [meta, file(tbi).name] },
-                    process.out.versions
-                ).match() }
-            )
-        }
-    }
-
-    test("germline vcf with tumor bam - filtered sites kept") {
-
-        when {
-            params {
-                // Without `--no-filtered` the low quality sites stay in the output, tagged
-                // in FILTER instead of being dropped
-                prepare_hetsnps_for_frankenplot_args = "--site-quality 100 --filter-hom"
-            }
-
-            process {
-                """
-                input[0] = channel.of([
-                    [ id:'TUMOR', case_id:'TEST', sample_name:'TUMOR', sample_type:'tumor' ],
-                    file(params.pipelines_testdata_base_path + 'testdata/vcf/NORMAL_haplotypecaller.vcf.gz', checkIfExists: true),
-                    file(params.pipelines_testdata_base_path + 'testdata/vcf/NORMAL_haplotypecaller.vcf.gz.tbi', checkIfExists: true),
-                    file(params.pipelines_testdata_base_path + 'testdata/bam/TUMOR_dedup.bam', checkIfExists: true),
-                    file(params.pipelines_testdata_base_path + 'testdata/bam/TUMOR_dedup.bai', checkIfExists: true)
-                ])
-                """
-            }
-        }
-
-        then {
-            assertAll(
-                { assert process.success },
-                { assert snapshot(
                     process.out.vcf.collect { meta, vcf -> [meta, "${file(vcf).name}:${path(vcf).vcf.variantsMD5}"] },
                     process.out.tbi.collect { meta, tbi -> [meta, file(tbi).name] },
                     process.out.versions
@@ -103,13 +67,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                // the empty `.vcf.gz` written by the stub cannot be decompressed and is
-                // serialised as an absolute work path, so only the file names are asserted
-                { assert snapshot(
-                    process.out.vcf.collect { meta, vcf -> [meta, file(vcf).name] },
-                    process.out.tbi.collect { meta, tbi -> [meta, file(tbi).name] },
-                    process.out.versions
-                ).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/local/prepare_hetsnps_for_frankenplot/tests/main.nf.test.snap
+++ b/modules/local/prepare_hetsnps_for_frankenplot/tests/main.nf.test.snap
@@ -1,0 +1,116 @@
+{
+    "germline vcf with tumor bam - filtered sites kept": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "TUMOR",
+                        "case_id": "TEST",
+                        "sample_name": "TUMOR",
+                        "sample_type": "tumor"
+                    },
+                    "TUMOR.hetsnps.vcf.gz:99379cd3b6b88bb6952cb13963040a55"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TUMOR",
+                        "case_id": "TEST",
+                        "sample_name": "TUMOR",
+                        "sample_type": "tumor"
+                    },
+                    "TUMOR.hetsnps.vcf.gz.tbi"
+                ]
+            ],
+            [
+                [
+                    "PREPARE_HETSNPS_FOR_FRANKENPLOT",
+                    "prepare_hetsnps_for_frankenplot",
+                    "prepare_hetsnps_for_frankenplot.py 1.0.0"
+                ]
+            ]
+        ],
+        "timestamp": "2026-09-01T12:19:23.96661939",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "26.04.6"
+        }
+    },
+    "germline vcf with tumor bam - stub": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "TUMOR",
+                        "case_id": "TEST",
+                        "sample_name": "TUMOR",
+                        "sample_type": "tumor"
+                    },
+                    "TUMOR.hetsnps.vcf.gz"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TUMOR",
+                        "case_id": "TEST",
+                        "sample_name": "TUMOR",
+                        "sample_type": "tumor"
+                    },
+                    "TUMOR.hetsnps.vcf.gz.tbi"
+                ]
+            ],
+            [
+                [
+                    "PREPARE_HETSNPS_FOR_FRANKENPLOT",
+                    "prepare_hetsnps_for_frankenplot",
+                    "prepare_hetsnps_for_frankenplot.py 1.0.0"
+                ]
+            ]
+        ],
+        "timestamp": "2026-09-01T12:20:20.217910112",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "26.04.6"
+        }
+    },
+    "germline vcf with tumor bam": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "TUMOR",
+                        "case_id": "TEST",
+                        "sample_name": "TUMOR",
+                        "sample_type": "tumor"
+                    },
+                    "TUMOR.hetsnps.vcf.gz:81c20457e174fdb5a65ddd5b4060f126"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "TUMOR",
+                        "case_id": "TEST",
+                        "sample_name": "TUMOR",
+                        "sample_type": "tumor"
+                    },
+                    "TUMOR.hetsnps.vcf.gz.tbi"
+                ]
+            ],
+            [
+                [
+                    "PREPARE_HETSNPS_FOR_FRANKENPLOT",
+                    "prepare_hetsnps_for_frankenplot",
+                    "prepare_hetsnps_for_frankenplot.py 1.0.0"
+                ]
+            ]
+        ],
+        "timestamp": "2026-09-01T12:19:18.018685916",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "26.04.6"
+        }
+    }
+}

--- a/modules/local/prepare_hetsnps_for_frankenplot/tests/main.nf.test.snap
+++ b/modules/local/prepare_hetsnps_for_frankenplot/tests/main.nf.test.snap
@@ -1,75 +1,39 @@
 {
-    "germline vcf with tumor bam - filtered sites kept": {
-        "content": [
-            [
-                [
-                    {
-                        "id": "TUMOR",
-                        "case_id": "TEST",
-                        "sample_name": "TUMOR",
-                        "sample_type": "tumor"
-                    },
-                    "TUMOR.hetsnps.vcf.gz:99379cd3b6b88bb6952cb13963040a55"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "TUMOR",
-                        "case_id": "TEST",
-                        "sample_name": "TUMOR",
-                        "sample_type": "tumor"
-                    },
-                    "TUMOR.hetsnps.vcf.gz.tbi"
-                ]
-            ],
-            [
-                [
-                    "PREPARE_HETSNPS_FOR_FRANKENPLOT",
-                    "prepare_hetsnps_for_frankenplot",
-                    "prepare_hetsnps_for_frankenplot.py 1.0.0"
-                ]
-            ]
-        ],
-        "timestamp": "2026-09-01T12:19:23.96661939",
-        "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "26.04.6"
-        }
-    },
     "germline vcf with tumor bam - stub": {
         "content": [
-            [
-                [
-                    {
-                        "id": "TUMOR",
-                        "case_id": "TEST",
-                        "sample_name": "TUMOR",
-                        "sample_type": "tumor"
-                    },
-                    "TUMOR.hetsnps.vcf.gz"
+            {
+                "tbi": [
+                    [
+                        {
+                            "id": "TUMOR",
+                            "case_id": "TEST",
+                            "sample_name": "TUMOR",
+                            "sample_type": "tumor"
+                        },
+                        "TUMOR.hetsnps.vcf.gz.tbi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "TUMOR",
+                            "case_id": "TEST",
+                            "sample_name": "TUMOR",
+                            "sample_type": "tumor"
+                        },
+                        "TUMOR.hetsnps.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions": [
+                    [
+                        "PREPARE_HETSNPS_FOR_FRANKENPLOT",
+                        "prepare_hetsnps_for_frankenplot",
+                        "prepare_hetsnps_for_frankenplot.py 1.0.0"
+                    ]
                 ]
-            ],
-            [
-                [
-                    {
-                        "id": "TUMOR",
-                        "case_id": "TEST",
-                        "sample_name": "TUMOR",
-                        "sample_type": "tumor"
-                    },
-                    "TUMOR.hetsnps.vcf.gz.tbi"
-                ]
-            ],
-            [
-                [
-                    "PREPARE_HETSNPS_FOR_FRANKENPLOT",
-                    "prepare_hetsnps_for_frankenplot",
-                    "prepare_hetsnps_for_frankenplot.py 1.0.0"
-                ]
-            ]
+            }
         ],
-        "timestamp": "2026-09-01T12:20:20.217910112",
+        "timestamp": "2026-09-01T15:24:59.500289146",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "26.04.6"
@@ -107,7 +71,7 @@
                 ]
             ]
         ],
-        "timestamp": "2026-09-01T12:19:18.018685916",
+        "timestamp": "2026-09-01T15:24:53.924117227",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "26.04.6"

--- a/modules/local/prepare_hetsnps_for_frankenplot/tests/nextflow.config
+++ b/modules/local/prepare_hetsnps_for_frankenplot/tests/nextflow.config
@@ -1,0 +1,6 @@
+process {
+    withName: PREPARE_HETSNPS_FOR_FRANKENPLOT {
+        ext.args   = params.prepare_hetsnps_for_frankenplot_args
+        ext.prefix = { "${meta.sample_name}" }
+    }
+}


### PR DESCRIPTION
Part of #12 

### Added

- `bin/prepare_hetsnps_for_frankenplot.py` -  filters a germline VCF down to heterozygous simple SNVs and appends a sample column with `GT`, `DP` and `AD` derived from a pileup of the tumour BAM, so B-allele frequencies can be plotted in a Frankenplot. Writes a bgzipped VCF plus tabix index. Optional `--site-quality`, `--filter-hom` and `--no-filtered` control quality/homozygote filtering and whether failing sites are dropped or just tagged in `FILTER`.
- `modules/local/prepare_hetsnps_for_frankenplot/` - module wrapping the script (pysam container), emitting `vcf` and `tbi`, with `meta.yml`, stub, and nf-test cases + snapshots.

